### PR TITLE
Add the choose network drop list

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -76,7 +76,13 @@ class HomeScreenState extends State<HomeScreen> {
     } else {
       return Scaffold(
         appBar: AppBar(
-          title: const Text('Silent Payments'),
+          title: Row(
+            children: [
+              const Text('Silent Payments'),
+              const Spacer(),
+              Text(walletState.network),
+            ],
+          ),
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         ),
         body: IndexedStack(

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:donationwallet/load_wallet.dart';
+import 'package:donationwallet/states/theme_notifier.dart';
 import 'package:donationwallet/states/wallet_state.dart';
 import 'package:donationwallet/tx_history.dart';
 import 'package:donationwallet/wallet.dart';
 import 'package:donationwallet/settings.dart';
 import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -33,12 +35,14 @@ class HomeScreenState extends State<HomeScreen> {
 
   Future<void> _checkWallet() async {
     final walletState = Provider.of<WalletState>(context, listen: false);
+    final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
     try {
       await walletState.updateWalletStatus();
       walletState.walletLoaded = true;
     } catch (e) {
       walletState.walletLoaded = false;
     }
+    themeNotifier.setTheme(walletState.network);
     setState(() {
       isLoading = false;
     });

--- a/lib/load_wallet.dart
+++ b/lib/load_wallet.dart
@@ -34,7 +34,7 @@ class LoadWalletScreenState extends State<LoadWalletScreen> {
   }
 
   Future<void> _setup(BuildContext context, String? mnemonic, String? scanKey,
-      String? spendKey) async {
+      String? spendKey, int? birthday) async {
     final walletState = Provider.of<WalletState>(context, listen: false);
     try {
       await walletState.updateWalletStatus();
@@ -44,13 +44,15 @@ class LoadWalletScreenState extends State<LoadWalletScreen> {
       Logger().i("Creating a new wallet");
     }
 
-    try {
-      await syncBlockchain(network: _network);
-    } catch (e) {
-      rethrow;
-    }
+    if (birthday == null) {
+      try {
+        await syncBlockchain(network: _network);
+      } catch (e) {
+        rethrow;
+      }
 
-    final birthday = walletState.tip;
+      birthday = walletState.tip;
+    }
 
     try {
       final wallet = await setup(
@@ -164,7 +166,7 @@ class LoadWalletScreenState extends State<LoadWalletScreen> {
                 }
 
                 try {
-                  await _setup(context, null, scanKey, spendKey);
+                  await _setup(context, null, scanKey, spendKey, birthday);
                   onSetupComplete(null);
                 } on Exception catch (e) {
                   onSetupComplete(e);
@@ -243,7 +245,7 @@ class LoadWalletScreenState extends State<LoadWalletScreen> {
                 final mnemonic = seedController.text;
                 final birthday = int.parse(birthdayController.text);
                 try {
-                  await _setup(context, mnemonic, null, null);
+                  await _setup(context, mnemonic, null, null, birthday);
                   onSetupComplete(null);
                 } on Exception catch (e) {
                   onSetupComplete(e);
@@ -298,7 +300,7 @@ class LoadWalletScreenState extends State<LoadWalletScreen> {
                   final walletState =
                       Provider.of<WalletState>(context, listen: false);
                   try {
-                    await _setup(context, null, null, null);
+                    await _setup(context, null, null, null, null);
                   } catch (e) {
                     rethrow;
                   }

--- a/lib/load_wallet.dart
+++ b/lib/load_wallet.dart
@@ -2,13 +2,63 @@ import 'dart:async';
 
 import 'package:donationwallet/home.dart';
 import 'package:donationwallet/rust/api/wallet.dart';
+import 'package:donationwallet/states/theme_notifier.dart';
 import 'package:donationwallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
-class LoadWalletScreen extends StatelessWidget {
+class LoadWalletScreen extends StatefulWidget {
   const LoadWalletScreen({super.key});
+
+  @override
+  LoadWalletScreenState createState() => LoadWalletScreenState();
+}
+
+class LoadWalletScreenState extends State<LoadWalletScreen> {
+  String _network = "signet";
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  void _updateTheme(String? newValue) {
+    final themeNotifier = Provider.of<ThemeNotifier>(context, listen: false);
+
+    ThemeData newTheme;
+    switch (newValue) {
+      case 'main':
+        newTheme = ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+          useMaterial3: true,
+        );
+        break;
+      case 'signet':
+        newTheme = ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.purple),
+          useMaterial3: true,
+        );
+        break;
+      case 'testnet':
+        newTheme = ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+          useMaterial3: true,
+        );
+        break;
+      default:
+        newTheme = ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.grey),
+          useMaterial3: true,
+        );
+        break;
+    }
+
+    themeNotifier.setTheme(newTheme);
+    setState(() {
+      _network = newValue!;
+    });
+  }
 
   Future<void> _setup(BuildContext context, String? mnemonic, String? scanKey,
       String? spendKey, int birthday) async {
@@ -28,7 +78,7 @@ class LoadWalletScreen extends StatelessWidget {
         scanKey: scanKey,
         spendKey: spendKey,
         birthday: birthday,
-        network: walletState.network,
+        network: _network,
       );
       await walletState.saveWalletToSecureStorage(wallet);
       await walletState.updateWalletStatus();
@@ -234,6 +284,29 @@ class LoadWalletScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            const Spacer(),
+            const Text(
+              'Select a Network',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 10),
+            DropdownButton<String>(
+              hint: const Text('Select a network'),
+              value: _network,
+              onChanged: (String? newValue) {
+                _updateTheme(newValue);
+              },
+              items: [
+                {'display': 'Bitcoin Mainnet', 'value': 'main'},
+                {'display': 'Signet', 'value': 'signet'},
+                {'display': 'Test', 'value': 'testnet'}
+              ].map<DropdownMenuItem<String>>((Map<String, String> item) {
+                return DropdownMenuItem<String>(
+                  value: item['value'],
+                  child: Text(item['display']!),
+                );
+              }).toList(),
+            ),
             const Spacer(),
             Expanded(
               child: _buildButton(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:donationwallet/rust/frb_generated.dart';
 
 import 'package:donationwallet/global_functions.dart';
@@ -13,12 +12,7 @@ void main() async {
   await RustLib.init();
   final walletState = WalletState();
   await walletState.initialize();
-  final themeNotifier = ThemeNotifier(
-    ThemeData(
-      colorScheme: ColorScheme.fromSeed(seedColor: Bitcoin.green),
-      useMaterial3: true,
-    ),
-  );
+  final themeNotifier = ThemeNotifier("signet");
   runApp(
     MultiProvider(
       providers: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:donationwallet/rust/frb_generated.dart';
 import 'package:donationwallet/global_functions.dart';
 import 'package:donationwallet/home.dart';
 import 'package:donationwallet/states/wallet_state.dart';
+import 'package:donationwallet/states/theme_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -12,9 +13,18 @@ void main() async {
   await RustLib.init();
   final walletState = WalletState();
   await walletState.initialize();
+  final themeNotifier = ThemeNotifier(
+    ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: Bitcoin.green),
+      useMaterial3: true,
+    ),
+  );
   runApp(
-    ChangeNotifierProvider.value(
-      value: walletState,
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(value: walletState),
+        ChangeNotifierProvider.value(value: themeNotifier),
+      ],
       child: const SilentPaymentApp(),
     ),
   );
@@ -25,13 +35,12 @@ class SilentPaymentApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeNotifier = Provider.of<ThemeNotifier>(context);
+
     return MaterialApp(
       title: 'Donation wallet',
       navigatorKey: globalNavigatorKey,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Bitcoin.green),
-        useMaterial3: true,
-      ),
+      theme: themeNotifier.themeData,
       home: const HomeScreen(),
     );
   }

--- a/lib/rust/api/psbt.dart
+++ b/lib/rust/api/psbt.dart
@@ -33,5 +33,5 @@ String signPsbt(
 String extractTxFromPsbt({required String psbt}) =>
     RustLib.instance.api.crateApiPsbtExtractTxFromPsbt(psbt: psbt);
 
-String broadcastTx({required String tx}) =>
-    RustLib.instance.api.crateApiPsbtBroadcastTx(tx: tx);
+String broadcastTx({required String tx, required String network}) =>
+    RustLib.instance.api.crateApiPsbtBroadcastTx(tx: tx, network: network);

--- a/lib/rust/api/structs.dart
+++ b/lib/rust/api/structs.dart
@@ -187,6 +187,7 @@ class RecordedTransactionOutgoing {
 
 class WalletStatus {
   final String address;
+  final String network;
   final BigInt balance;
   final int birthday;
   final int lastScan;
@@ -195,6 +196,7 @@ class WalletStatus {
 
   const WalletStatus({
     required this.address,
+    required this.network,
     required this.balance,
     required this.birthday,
     required this.lastScan,
@@ -205,6 +207,7 @@ class WalletStatus {
   @override
   int get hashCode =>
       address.hashCode ^
+      network.hashCode ^
       balance.hashCode ^
       birthday.hashCode ^
       lastScan.hashCode ^
@@ -217,6 +220,7 @@ class WalletStatus {
       other is WalletStatus &&
           runtimeType == other.runtimeType &&
           address == other.address &&
+          network == other.network &&
           balance == other.balance &&
           birthday == other.birthday &&
           lastScan == other.lastScan &&

--- a/lib/rust/api/wallet.dart
+++ b/lib/rust/api/wallet.dart
@@ -32,11 +32,13 @@ String changeBirthday({required String encodedWallet, required int birthday}) =>
 String resetWallet({required String encodedWallet}) => RustLib.instance.api
     .crateApiWalletResetWallet(encodedWallet: encodedWallet);
 
-Future<void> syncBlockchain() =>
-    RustLib.instance.api.crateApiWalletSyncBlockchain();
+Future<void> syncBlockchain({required String network}) =>
+    RustLib.instance.api.crateApiWalletSyncBlockchain(network: network);
 
-Future<String> scanToTip({required String encodedWallet}) =>
-    RustLib.instance.api.crateApiWalletScanToTip(encodedWallet: encodedWallet);
+Future<String> scanToTip(
+        {required String encodedWallet, required String network}) =>
+    RustLib.instance.api.crateApiWalletScanToTip(
+        encodedWallet: encodedWallet, network: network);
 
 WalletStatus getWalletInfo({required String encodedWallet}) =>
     RustLib.instance.api

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -76,7 +76,7 @@ abstract class RustLibApi extends BaseApi {
   String crateApiPsbtAddFeeForFeeRate(
       {required String psbt, required int feeRate, required String payer});
 
-  String crateApiPsbtBroadcastTx({required String tx});
+  String crateApiPsbtBroadcastTx({required String tx, required String network});
 
   String crateApiPsbtCreateNewPsbt(
       {required String encodedWallet,
@@ -188,11 +188,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  String crateApiPsbtBroadcastTx({required String tx}) {
+  String crateApiPsbtBroadcastTx(
+      {required String tx, required String network}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(tx, serializer);
+        sse_encode_String(network, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
       },
       codec: SseCodec(
@@ -200,14 +202,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiPsbtBroadcastTxConstMeta,
-      argValues: [tx],
+      argValues: [tx, network],
       apiImpl: this,
     ));
   }
 
   TaskConstMeta get kCrateApiPsbtBroadcastTxConstMeta => const TaskConstMeta(
         debugName: "broadcast_tx",
-        argNames: ["tx"],
+        argNames: ["tx", "network"],
       );
 
   @override

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -136,7 +136,8 @@ abstract class RustLibApi extends BaseApi {
 
   String crateApiWalletResetWallet({required String encodedWallet});
 
-  Future<String> crateApiWalletScanToTip({required String encodedWallet});
+  Future<String> crateApiWalletScanToTip(
+      {required String encodedWallet, required String network});
 
   Future<String> crateApiWalletSetup(
       {required String label,
@@ -148,7 +149,7 @@ abstract class RustLibApi extends BaseApi {
 
   String? crateApiWalletShowMnemonic({required String encodedWallet});
 
-  Future<void> crateApiWalletSyncBlockchain();
+  Future<void> crateApiWalletSyncBlockchain({required String network});
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -684,11 +685,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String> crateApiWalletScanToTip({required String encodedWallet}) {
+  Future<String> crateApiWalletScanToTip(
+      {required String encodedWallet, required String network}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
+        sse_encode_String(network, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 21, port: port_);
       },
@@ -697,14 +700,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiWalletScanToTipConstMeta,
-      argValues: [encodedWallet],
+      argValues: [encodedWallet, network],
       apiImpl: this,
     ));
   }
 
   TaskConstMeta get kCrateApiWalletScanToTipConstMeta => const TaskConstMeta(
         debugName: "scan_to_tip",
-        argNames: ["encodedWallet"],
+        argNames: ["encodedWallet", "network"],
       );
 
   @override
@@ -773,10 +776,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<void> crateApiWalletSyncBlockchain() {
+  Future<void> crateApiWalletSyncBlockchain({required String network}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(network, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 24, port: port_);
       },
@@ -785,7 +789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiWalletSyncBlockchainConstMeta,
-      argValues: [],
+      argValues: [network],
       apiImpl: this,
     ));
   }
@@ -793,7 +797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiWalletSyncBlockchainConstMeta =>
       const TaskConstMeta(
         debugName: "sync_blockchain",
-        argNames: [],
+        argNames: ["network"],
       );
 
   @protected
@@ -1120,15 +1124,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletStatus dco_decode_wallet_status(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return WalletStatus(
       address: dco_decode_String(arr[0]),
-      balance: dco_decode_u_64(arr[1]),
-      birthday: dco_decode_u_32(arr[2]),
-      lastScan: dco_decode_u_32(arr[3]),
-      outputs: dco_decode_Map_String_owned_output(arr[4]),
-      txHistory: dco_decode_list_recorded_transaction(arr[5]),
+      network: dco_decode_String(arr[1]),
+      balance: dco_decode_u_64(arr[2]),
+      birthday: dco_decode_u_32(arr[3]),
+      lastScan: dco_decode_u_32(arr[4]),
+      outputs: dco_decode_Map_String_owned_output(arr[5]),
+      txHistory: dco_decode_list_recorded_transaction(arr[6]),
     );
   }
 
@@ -1481,6 +1486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletStatus sse_decode_wallet_status(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_address = sse_decode_String(deserializer);
+    var var_network = sse_decode_String(deserializer);
     var var_balance = sse_decode_u_64(deserializer);
     var var_birthday = sse_decode_u_32(deserializer);
     var var_lastScan = sse_decode_u_32(deserializer);
@@ -1488,6 +1494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_txHistory = sse_decode_list_recorded_transaction(deserializer);
     return WalletStatus(
         address: var_address,
+        network: var_network,
         balance: var_balance,
         birthday: var_birthday,
         lastScan: var_lastScan,
@@ -1814,6 +1821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_wallet_status(WalletStatus self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.address, serializer);
+    sse_encode_String(self.network, serializer);
     sse_encode_u_64(self.balance, serializer);
     sse_encode_u_32(self.birthday, serializer);
     sse_encode_u_32(self.lastScan, serializer);

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
 import 'package:donationwallet/global_functions.dart';
 import 'package:donationwallet/rust/api/wallet.dart';
+import 'package:donationwallet/states/wallet_state.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class SynchronizationService {
+  final BuildContext context;
   Timer? _timer;
   final Duration _interval = const Duration(minutes: 10);
+
+  SynchronizationService(this.context);
 
   void startSyncTimer() {
     _scheduleNextTask();
@@ -20,7 +26,7 @@ class SynchronizationService {
 
   Future<void> performSynchronizationTask() async {
     try {
-      await syncBlockchain();
+      await syncBlockchain(network: Provider.of<WalletState>(context, listen: false).network);
     } catch (e) {
       displayNotification(e.toString());
     }

--- a/lib/spend.dart
+++ b/lib/spend.dart
@@ -102,11 +102,11 @@ class SpendScreen extends StatelessWidget {
     return signPsbt(encodedWallet: wallet, psbt: unsignedPsbt, finalize: true);
   }
 
-  String _broadcastSignedPsbt(String signedPsbt) {
+  String _broadcastSignedPsbt(String signedPsbt, String network) {
     try {
       final tx = extractTxFromPsbt(psbt: signedPsbt);
       print(tx);
-      final txid = broadcastTx(tx: tx);
+      final txid = broadcastTx(tx: tx, network: network);
       return txid;
     } catch (e) {
       rethrow;
@@ -209,7 +209,8 @@ class SpendScreen extends StatelessWidget {
                       walletState.recipients,
                       fees);
                   final signedPsbt = _signPsbt(wallet, unsignedPsbt);
-                  final sentTxId = _broadcastSignedPsbt(signedPsbt);
+                  final sentTxId =
+                      _broadcastSignedPsbt(signedPsbt, walletState.network);
                   final markedAsSpentWallet = _markAsSpent(
                       wallet, sentTxId, walletState.selectedOutputs);
                   final updatedWallet = _addTxToHistory(

--- a/lib/states/theme_notifier.dart
+++ b/lib/states/theme_notifier.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class ThemeNotifier extends ChangeNotifier {
+  ThemeData _themeData;
+
+  ThemeNotifier(this._themeData);
+
+  ThemeData get themeData => _themeData;
+
+  void setTheme(ThemeData themeData) {
+    _themeData = themeData;
+    notifyListeners();
+  }
+}

--- a/lib/states/theme_notifier.dart
+++ b/lib/states/theme_notifier.dart
@@ -1,14 +1,39 @@
 import 'package:flutter/material.dart';
 
 class ThemeNotifier extends ChangeNotifier {
-  ThemeData _themeData;
+  late ThemeData _themeData;
 
-  ThemeNotifier(this._themeData);
+  ThemeNotifier(String network) : _themeData = _getThemeFromNetwork(network);
 
   ThemeData get themeData => _themeData;
 
-  void setTheme(ThemeData themeData) {
-    _themeData = themeData;
+  static ThemeData _getThemeFromNetwork(String network) {
+    switch (network) {
+      case 'main':
+        return ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+          useMaterial3: true,
+        );
+      case 'signet':
+        return ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.purple),
+          useMaterial3: true,
+        );
+      case 'test':
+        return ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
+          useMaterial3: true,
+        );
+      default:
+        return ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.grey),
+          useMaterial3: true,
+        );
+    }
+  }
+
+  void setTheme(String network) {
+    _themeData = _getThemeFromNetwork(network);
     notifyListeners();
   }
 }

--- a/lib/wallet.dart
+++ b/lib/wallet.dart
@@ -2,14 +2,36 @@ import 'dart:async';
 
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:donationwallet/global_functions.dart';
+import 'package:donationwallet/services/synchronization_service.dart';
 import 'package:donationwallet/spend.dart';
 import 'package:donationwallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 import 'package:barcode_widget/barcode_widget.dart';
 
-class WalletScreen extends StatelessWidget {
+class WalletScreen extends StatefulWidget {
   const WalletScreen({super.key});
+
+  @override
+  WalletScreenState createState() => WalletScreenState();
+}
+
+class WalletScreenState extends State<WalletScreen> {
+  late SynchronizationService _synchronizationService;
+
+  @override
+  void initState() {
+    super.initState(); 
+    _synchronizationService = SynchronizationService(context);
+    _synchronizationService.startSyncTimer();
+  }
+
+  @override
+  void dispose() {
+    _synchronizationService.stopSyncTimer();
+    super.dispose();
+  }
 
   Future<void> _updateOwnedOutputs(
       WalletState walletState, Function(Exception? e) callback) async {
@@ -63,7 +85,8 @@ class WalletScreen extends StatelessWidget {
     } else if (toScan == 0) {
       text = 'Up to date!';
     } else {
-      text = 'New blocks: $toScan';
+      text = 'tip: ${walletState.tip} lastScan: ${walletState.lastScan}';
+      // text = 'New blocks: $toScan';
     }
 
     return Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -456,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: "697d067c60c20999686a0add96cf6aba723b3aa1f83ecf806a8097231529ec32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   bitcoin_ui: ^2.0.0
   rust_lib_donationwallet:
     path: rust_builder
+  logger: ^2.4.0
 
 dev_dependencies:
   flutter_test:

--- a/rust/src/api/structs.rs
+++ b/rust/src/api/structs.rs
@@ -240,6 +240,7 @@ impl From<RecordedTransactionOutgoing> for sp_client::spclient::RecordedTransact
 
 pub struct WalletStatus {
     pub address: String,
+    pub network: String,
     pub balance: u64,
     pub birthday: u32,
     pub last_scan: u32,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -100,11 +100,14 @@ pub fn reset_wallet(encoded_wallet: String) -> Result<String> {
 }
 
 pub async fn sync_blockchain(network: String) -> Result<()> {
+    let network = Network::from_core_arg(&network)?;
+
     blindbit::logic::sync_blockchain(network).await
 }
 
 pub async fn scan_to_tip(encoded_wallet: String, network: String) -> Result<String> {
     let mut wallet: SpWallet = serde_json::from_str(&encoded_wallet)?;
+    let network = Network::from_core_arg(&network)?;
     blindbit::logic::scan_blocks(0, &mut wallet, network).await?;
     Ok(serde_json::to_string(&wallet)?)
 }

--- a/rust/src/blindbit/logic.rs
+++ b/rust/src/blindbit/logic.rs
@@ -24,11 +24,17 @@ use crate::{
 
 use super::client::FilterResponse;
 
-const HOST: &str = "https://silentpayments.dev/blindbit/signet";
+const HOST: &str = "https://silentpayments.dev/blindbit";
 const CONCURRENT_FILTER_REQUESTS: usize = 200;
 
-pub async fn sync_blockchain() -> Result<()> {
-    let blindbit_client = BlindbitClient::new(HOST.to_string());
+pub async fn sync_blockchain(network: String) -> Result<()> {
+    let blindbit_client: BlindbitClient;
+    match network.as_str() {
+        "main" => blindbit_client = BlindbitClient::new(format!("{}/mainnet", HOST)),
+        "test" => blindbit_client = BlindbitClient::new(format!("{}/testnet", HOST)),
+        "signet" => blindbit_client = BlindbitClient::new(format!("{}/signet", HOST)),
+        _ => return Err(Error::msg("unknown network"))
+    }
 
     let height = blindbit_client.block_height().await?;
 
@@ -39,8 +45,14 @@ pub async fn sync_blockchain() -> Result<()> {
     Ok(())
 }
 
-pub async fn scan_blocks(mut n_blocks_to_scan: u32, sp_wallet: &mut SpWallet) -> Result<()> {
-    let blindbit_client = BlindbitClient::new(HOST.to_string());
+pub async fn scan_blocks(mut n_blocks_to_scan: u32, sp_wallet: &mut SpWallet, network: String) -> Result<()> {
+    let blindbit_client: BlindbitClient;
+    match network.as_str() {
+        "main" => blindbit_client = BlindbitClient::new(format!("{}/mainnet", HOST)),
+        "test" => blindbit_client = BlindbitClient::new(format!("{}/testnet", HOST)),
+        "signet" => blindbit_client = BlindbitClient::new(format!("{}/signet", HOST)),
+        _ => return Err(Error::msg("unknown network"))
+    }
 
     let last_scan = sp_wallet.get_outputs().get_last_scan();
     let tip_height = blindbit_client.block_height().await?;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -94,8 +94,11 @@ fn wire__crate__api__psbt__broadcast_tx_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_tx = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse((move || crate::api::psbt::broadcast_tx(api_tx))())
+            transform_result_sse((move || {
+                crate::api::psbt::broadcast_tx(api_tx, api_network)
+            })())
         },
     )
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -700,11 +700,15 @@ fn wire__crate__api__wallet__scan_to_tip_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_encoded_wallet = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
-                transform_result_sse((move || async move {
-                         crate::api::wallet::scan_to_tip(api_encoded_wallet).await
-                    })().await)
+                transform_result_sse(
+                    (move || async move {
+                        crate::api::wallet::scan_to_tip(api_encoded_wallet, api_network).await
+                    })()
+                    .await,
+                )
             }
         },
     )
@@ -808,11 +812,12 @@ fn wire__crate__api__wallet__sync_blockchain_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_network = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
-                transform_result_sse(
-                    (move || async move { crate::api::wallet::sync_blockchain().await })().await,
-                )
+                transform_result_sse((move || async move {
+                         crate::api::wallet::sync_blockchain(api_network).await
+                    })().await)
             }
         },
     )
@@ -1201,6 +1206,7 @@ impl SseDecode for crate::api::structs::WalletStatus {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_address = <String>::sse_decode(deserializer);
+        let mut var_network = <String>::sse_decode(deserializer);
         let mut var_balance = <u64>::sse_decode(deserializer);
         let mut var_birthday = <u32>::sse_decode(deserializer);
         let mut var_lastScan = <u32>::sse_decode(deserializer);
@@ -1212,6 +1218,7 @@ impl SseDecode for crate::api::structs::WalletStatus {
             <Vec<crate::api::structs::RecordedTransaction>>::sse_decode(deserializer);
         return crate::api::structs::WalletStatus {
             address: var_address,
+            network: var_network,
             balance: var_balance,
             birthday: var_birthday,
             last_scan: var_lastScan,
@@ -1513,6 +1520,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::structs::WalletStatus {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.address.into_into_dart().into_dart(),
+            self.network.into_into_dart().into_dart(),
             self.balance.into_into_dart().into_dart(),
             self.birthday.into_into_dart().into_dart(),
             self.last_scan.into_into_dart().into_dart(),
@@ -1848,6 +1856,7 @@ impl SseEncode for crate::api::structs::WalletStatus {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.address, serializer);
+        <String>::sse_encode(self.network, serializer);
         <u64>::sse_encode(self.balance, serializer);
         <u32>::sse_encode(self.birthday, serializer);
         <u32>::sse_encode(self.last_scan, serializer);


### PR DESCRIPTION
So far we didn't left options to change the network in the interface, which means that switching network needed modifying hardcoded values and building again. 

This small PR simply added the drop down menu in the wallet creation screen, actually implementing all the switching network logic will first need to correct some inconsistencies up to the rust-silentpayment crate, so I'd rather leave it here for now. 

This can be merged now but I'd rather rebase it later on the sp_client_refactor branch once that one is merged, as it will probably make the still needed changes simpler. 