### PR TITLE
Add spent outpoints to outgoing transaction history

### DIFF
--- a/lib/rust/api/simple.dart
+++ b/lib/rust/api/simple.dart
@@ -100,9 +100,13 @@ String markOutpointsSpent(
 String addOutgoingTxToHistory(
         {required String encodedWallet,
         required String txid,
+        required List<String> spentOutpoints,
         required List<Recipient> recipients}) =>
     RustLib.instance.api.crateApiSimpleAddOutgoingTxToHistory(
-        encodedWallet: encodedWallet, txid: txid, recipients: recipients);
+        encodedWallet: encodedWallet,
+        txid: txid,
+        spentOutpoints: spentOutpoints,
+        recipients: recipients);
 
 String addIncomingTxToHistory(
         {required String encodedWallet,
@@ -259,11 +263,13 @@ class RecordedTransactionIncoming {
 
 class RecordedTransactionOutgoing {
   final String txid;
+  final List<String> spentOutpoints;
   final List<Recipient> recipients;
   final int? confirmedAt;
 
   const RecordedTransactionOutgoing({
     required this.txid,
+    required this.spentOutpoints,
     required this.recipients,
     this.confirmedAt,
   });
@@ -275,7 +281,10 @@ class RecordedTransactionOutgoing {
 
   @override
   int get hashCode =>
-      txid.hashCode ^ recipients.hashCode ^ confirmedAt.hashCode;
+      txid.hashCode ^
+      spentOutpoints.hashCode ^
+      recipients.hashCode ^
+      confirmedAt.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -283,6 +292,7 @@ class RecordedTransactionOutgoing {
       other is RecordedTransactionOutgoing &&
           runtimeType == other.runtimeType &&
           txid == other.txid &&
+          spentOutpoints == other.spentOutpoints &&
           recipients == other.recipients &&
           confirmedAt == other.confirmedAt;
 }

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -81,6 +81,7 @@ abstract class RustLibApi extends BaseApi {
   String crateApiSimpleAddOutgoingTxToHistory(
       {required String encodedWallet,
       required String txid,
+      required List<String> spentOutpoints,
       required List<Recipient> recipients});
 
   BigInt crateApiSimpleAmountToInt({required Amount that});
@@ -216,12 +217,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String crateApiSimpleAddOutgoingTxToHistory(
       {required String encodedWallet,
       required String txid,
+      required List<String> spentOutpoints,
       required List<Recipient> recipients}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encodedWallet, serializer);
         sse_encode_String(txid, serializer);
+        sse_encode_list_String(spentOutpoints, serializer);
         sse_encode_list_recipient(recipients, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
       },
@@ -230,7 +233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiSimpleAddOutgoingTxToHistoryConstMeta,
-      argValues: [encodedWallet, txid, recipients],
+      argValues: [encodedWallet, txid, spentOutpoints, recipients],
       apiImpl: this,
     ));
   }
@@ -238,7 +241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSimpleAddOutgoingTxToHistoryConstMeta =>
       const TaskConstMeta(
         debugName: "add_outgoing_tx_to_history",
-        argNames: ["encodedWallet", "txid", "recipients"],
+        argNames: ["encodedWallet", "txid", "spentOutpoints", "recipients"],
       );
 
   @override
@@ -1053,12 +1056,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return RecordedTransactionOutgoing(
       txid: dco_decode_String(arr[0]),
-      recipients: dco_decode_list_recipient(arr[1]),
-      confirmedAt: dco_decode_opt_box_autoadd_u_32(arr[2]),
+      spentOutpoints: dco_decode_list_String(arr[1]),
+      recipients: dco_decode_list_recipient(arr[2]),
+      confirmedAt: dco_decode_opt_box_autoadd_u_32(arr[3]),
     );
   }
 
@@ -1422,10 +1426,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_txid = sse_decode_String(deserializer);
+    var var_spentOutpoints = sse_decode_list_String(deserializer);
     var var_recipients = sse_decode_list_recipient(deserializer);
     var var_confirmedAt = sse_decode_opt_box_autoadd_u_32(deserializer);
     return RecordedTransactionOutgoing(
         txid: var_txid,
+        spentOutpoints: var_spentOutpoints,
         recipients: var_recipients,
         confirmedAt: var_confirmedAt);
   }
@@ -1760,6 +1766,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       RecordedTransactionOutgoing self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.txid, serializer);
+    sse_encode_list_String(self.spentOutpoints, serializer);
     sse_encode_list_recipient(self.recipients, serializer);
     sse_encode_opt_box_autoadd_u_32(self.confirmedAt, serializer);
   }

--- a/lib/spend.dart
+++ b/lib/spend.dart
@@ -127,11 +127,14 @@ class SpendScreen extends StatelessWidget {
     }
   }
 
-  String _addTxToHistory(
-      String wallet, String txid, List<Recipient> recipients) {
+  String _addTxToHistory(String wallet, String txid,
+      List<String> selectedOutpoints, List<Recipient> recipients) {
     try {
       final updatedWallet = addOutgoingTxToHistory(
-          encodedWallet: wallet, txid: txid, recipients: recipients);
+          encodedWallet: wallet,
+          txid: txid,
+          spentOutpoints: selectedOutpoints,
+          recipients: recipients);
       return updatedWallet;
     } catch (e) {
       rethrow;
@@ -208,7 +211,10 @@ class SpendScreen extends StatelessWidget {
                   final markedAsSpentWallet = _markAsSpent(
                       wallet, sentTxId, walletState.selectedOutputs);
                   final updatedWallet = _addTxToHistory(
-                      markedAsSpentWallet, sentTxId, walletState.recipients);
+                      markedAsSpentWallet,
+                      sentTxId,
+                      walletState.selectedOutputs.keys.toList(),
+                      walletState.recipients);
 
                   // Clear selections
                   walletState.selectedOutputs.clear();

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "sp_client"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/sp-client?branch=master#82ed3d5b7c01fc19a023728195e8e5554e0bc023"
+source = "git+https://github.com/cygnet3/sp-client?branch=master#35dd4c490033b80541b60fd8145f0779b28e74e2"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -132,6 +132,7 @@ fn wire__crate__api__simple__add_outgoing_tx_to_history_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_encoded_wallet = <String>::sse_decode(&mut deserializer);
             let api_txid = <String>::sse_decode(&mut deserializer);
+            let api_spent_outpoints = <Vec<String>>::sse_decode(&mut deserializer);
             let api_recipients =
                 <Vec<crate::api::simple::Recipient>>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -139,6 +140,7 @@ fn wire__crate__api__simple__add_outgoing_tx_to_history_impl(
                 crate::api::simple::add_outgoing_tx_to_history(
                     api_encoded_wallet,
                     api_txid,
+                    api_spent_outpoints,
                     api_recipients,
                 )
             })())
@@ -1132,10 +1134,12 @@ impl SseDecode for crate::api::simple::RecordedTransactionOutgoing {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_spentOutpoints = <Vec<String>>::sse_decode(deserializer);
         let mut var_recipients = <Vec<crate::api::simple::Recipient>>::sse_decode(deserializer);
         let mut var_confirmedAt = <Option<u32>>::sse_decode(deserializer);
         return crate::api::simple::RecordedTransactionOutgoing {
             txid: var_txid,
+            spent_outpoints: var_spentOutpoints,
             recipients: var_recipients,
             confirmed_at: var_confirmedAt,
         };
@@ -1445,6 +1449,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::simple::RecordedTransactionOu
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.txid.into_into_dart().into_dart(),
+            self.spent_outpoints.into_into_dart().into_dart(),
             self.recipients.into_into_dart().into_dart(),
             self.confirmed_at.into_into_dart().into_dart(),
         ]
@@ -1781,6 +1786,7 @@ impl SseEncode for crate::api::simple::RecordedTransactionOutgoing {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.txid, serializer);
+        <Vec<String>>::sse_encode(self.spent_outpoints, serializer);
         <Vec<crate::api::simple::Recipient>>::sse_encode(self.recipients, serializer);
         <Option<u32>>::sse_encode(self.confirmed_at, serializer);
     }


### PR DESCRIPTION
This is needed to fix a bug with confirming outgoing transactions. Before, confirmation was based on the txid. But blindbit oracle doesn't show the txid for found inputs.