### PR TITLE
Show 'sync offline' instead of displaying error notification

### DIFF
--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -58,8 +58,9 @@ class SynchronizationService {
       }
 
       // fetch new tip before syncing
-      await _performChainUpdateTask();
-      await _performSynchronizationTask();
+      if (await _performChainUpdateTask()) {
+        await _performSynchronizationTask();
+      }
     } on Exception catch (e) {
       // todo: we should have a connection status with the server
       // e.g. a green or red circle based on whether we have connection issues
@@ -77,8 +78,8 @@ class SynchronizationService {
     });
   }
 
-  Future<void> _performChainUpdateTask() async {
-    await chainState.updateChainTip();
+  Future<bool> _performChainUpdateTask() async {
+    return await chainState.updateChainTip();
   }
 
   Future<void> _performSynchronizationTask() async {

--- a/lib/states/chain_state.dart
+++ b/lib/states/chain_state.dart
@@ -32,8 +32,8 @@ class ChainState extends ChangeNotifier {
     _network = network;
   }
 
-  void startSyncService(
-      WalletState walletState, ScanProgressNotifier scanProgress, bool immediate) {
+  void startSyncService(WalletState walletState,
+      ScanProgressNotifier scanProgress, bool immediate) {
     // start sync service & timer
     _synchronizationService = SynchronizationService(
         chainState: this, walletState: walletState, scanProgress: scanProgress);
@@ -99,18 +99,22 @@ class ChainState extends ChangeNotifier {
     }
   }
 
-  Future<void> updateChainTip() async {
+  Future<bool> updateChainTip() async {
     if (!available) {
       Logger().w('Cannot update chain tip: chain state not available');
-      return;
+      return false;
     }
 
     try {
       _tip = await getChainHeight(blindbitUrl: _blindbitUrl!);
       Logger().i('updating tip: $_tip');
       notifyListeners();
+      return true;
     } catch (e) {
       Logger().e('Failed to update chain tip: $e');
+      _tip = null;
+      notifyListeners();
+      return false;
     }
   }
 


### PR DESCRIPTION
- Set the tip height to `null` and notify the chain listeners
- Don't try to perform the synchronization task after chain update fails, as this will always fail. This resulted in a error popup, but the 'sync offline' banner should be enough by itself.