### PR TITLE
Decode with native structs

### DIFF
--- a/lib/generated/rust/api/structs.freezed.dart
+++ b/lib/generated/rust/api/structs.freezed.dart
@@ -79,9 +79,6 @@ class _$ApiOutputSpendStatusCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -101,9 +98,6 @@ class __$$ApiOutputSpendStatus_UnspentImplCopyWithImpl<$Res>
       _$ApiOutputSpendStatus_UnspentImpl _value,
       $Res Function(_$ApiOutputSpendStatus_UnspentImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -221,8 +215,6 @@ class __$$ApiOutputSpendStatus_SpentImplCopyWithImpl<$Res>
       $Res Function(_$ApiOutputSpendStatus_SpentImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -261,9 +253,7 @@ class _$ApiOutputSpendStatus_SpentImpl extends ApiOutputSpendStatus_Spent {
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApiOutputSpendStatus_SpentImplCopyWith<_$ApiOutputSpendStatus_SpentImpl>
@@ -345,10 +335,7 @@ abstract class ApiOutputSpendStatus_Spent extends ApiOutputSpendStatus {
   const ApiOutputSpendStatus_Spent._() : super._();
 
   String get field0;
-
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApiOutputSpendStatus_SpentImplCopyWith<_$ApiOutputSpendStatus_SpentImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -373,8 +360,6 @@ class __$$ApiOutputSpendStatus_MinedImplCopyWithImpl<$Res>
       $Res Function(_$ApiOutputSpendStatus_MinedImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -413,9 +398,7 @@ class _$ApiOutputSpendStatus_MinedImpl extends ApiOutputSpendStatus_Mined {
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApiOutputSpendStatus_MinedImplCopyWith<_$ApiOutputSpendStatus_MinedImpl>
@@ -497,10 +480,7 @@ abstract class ApiOutputSpendStatus_Mined extends ApiOutputSpendStatus {
   const ApiOutputSpendStatus_Mined._() : super._();
 
   String get field0;
-
-  /// Create a copy of ApiOutputSpendStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApiOutputSpendStatus_MinedImplCopyWith<_$ApiOutputSpendStatus_MinedImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -565,9 +545,6 @@ class _$ApiRecordedTransactionCopyWithImpl<$Res,
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -590,8 +567,6 @@ class __$$ApiRecordedTransaction_IncomingImplCopyWithImpl<$Res>
       $Res Function(_$ApiRecordedTransaction_IncomingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -631,9 +606,7 @@ class _$ApiRecordedTransaction_IncomingImpl
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApiRecordedTransaction_IncomingImplCopyWith<
@@ -712,10 +685,7 @@ abstract class ApiRecordedTransaction_Incoming extends ApiRecordedTransaction {
 
   @override
   ApiRecordedTransactionIncoming get field0;
-
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApiRecordedTransaction_IncomingImplCopyWith<
           _$ApiRecordedTransaction_IncomingImpl>
       get copyWith => throw _privateConstructorUsedError;
@@ -741,8 +711,6 @@ class __$$ApiRecordedTransaction_OutgoingImplCopyWithImpl<$Res>
       $Res Function(_$ApiRecordedTransaction_OutgoingImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -782,9 +750,7 @@ class _$ApiRecordedTransaction_OutgoingImpl
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ApiRecordedTransaction_OutgoingImplCopyWith<
@@ -863,10 +829,7 @@ abstract class ApiRecordedTransaction_Outgoing extends ApiRecordedTransaction {
 
   @override
   ApiRecordedTransactionOutgoing get field0;
-
-  /// Create a copy of ApiRecordedTransaction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$ApiRecordedTransaction_OutgoingImplCopyWith<
           _$ApiRecordedTransaction_OutgoingImpl>
       get copyWith => throw _privateConstructorUsedError;

--- a/lib/generated/rust/api/wallet/setup.freezed.dart
+++ b/lib/generated/rust/api/wallet/setup.freezed.dart
@@ -84,9 +84,6 @@ class _$WalletSetupTypeCopyWithImpl<$Res, $Val extends WalletSetupType>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
-
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -105,9 +102,6 @@ class __$$WalletSetupType_NewWalletImplCopyWithImpl<$Res>
       _$WalletSetupType_NewWalletImpl _value,
       $Res Function(_$WalletSetupType_NewWalletImpl) _then)
       : super(_value, _then);
-
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -229,8 +223,6 @@ class __$$WalletSetupType_MnemonicImplCopyWithImpl<$Res>
       $Res Function(_$WalletSetupType_MnemonicImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -269,9 +261,7 @@ class _$WalletSetupType_MnemonicImpl extends WalletSetupType_Mnemonic {
   @override
   int get hashCode => Object.hash(runtimeType, field0);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$WalletSetupType_MnemonicImplCopyWith<_$WalletSetupType_MnemonicImpl>
@@ -359,10 +349,7 @@ abstract class WalletSetupType_Mnemonic extends WalletSetupType {
   const WalletSetupType_Mnemonic._() : super._();
 
   String get field0;
-
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$WalletSetupType_MnemonicImplCopyWith<_$WalletSetupType_MnemonicImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -384,8 +371,6 @@ class __$$WalletSetupType_FullImplCopyWithImpl<$Res>
       $Res Function(_$WalletSetupType_FullImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -432,9 +417,7 @@ class _$WalletSetupType_FullImpl extends WalletSetupType_Full {
   @override
   int get hashCode => Object.hash(runtimeType, field0, field1);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$WalletSetupType_FullImplCopyWith<_$WalletSetupType_FullImpl>
@@ -524,10 +507,7 @@ abstract class WalletSetupType_Full extends WalletSetupType {
 
   String get field0;
   String get field1;
-
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$WalletSetupType_FullImplCopyWith<_$WalletSetupType_FullImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -551,8 +531,6 @@ class __$$WalletSetupType_WatchOnlyImplCopyWithImpl<$Res>
       $Res Function(_$WalletSetupType_WatchOnlyImpl) _then)
       : super(_value, _then);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -599,9 +577,7 @@ class _$WalletSetupType_WatchOnlyImpl extends WalletSetupType_WatchOnly {
   @override
   int get hashCode => Object.hash(runtimeType, field0, field1);
 
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$WalletSetupType_WatchOnlyImplCopyWith<_$WalletSetupType_WatchOnlyImpl>
@@ -691,10 +667,7 @@ abstract class WalletSetupType_WatchOnly extends WalletSetupType {
 
   String get field0;
   String get field1;
-
-  /// Create a copy of WalletSetupType
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
+  @JsonKey(ignore: true)
   _$$WalletSetupType_WatchOnlyImplCopyWith<_$WalletSetupType_WatchOnlyImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/generated/rust/frb_generated.dart
+++ b/lib/generated/rust/frb_generated.dart
@@ -807,7 +807,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       codec: SseCodec(
         decodeSuccessData:
             sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOwnedOutputs,
-        decodeErrorData: null,
+        decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiOutputsOwnedOutputsDecodeConstMeta,
       argValues: [encodedOutputs],
@@ -856,7 +856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
-        decodeErrorData: null,
+        decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiOutputsOwnedOutputsEncodeConstMeta,
       argValues: [that],
@@ -1699,7 +1699,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       codec: SseCodec(
         decodeSuccessData:
             sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTxHistory,
-        decodeErrorData: null,
+        decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiHistoryTxHistoryDecodeConstMeta,
       argValues: [encodedHistory],
@@ -1748,7 +1748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
-        decodeErrorData: null,
+        decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiHistoryTxHistoryEncodeConstMeta,
       argValues: [that],

--- a/rust/src/api/history.rs
+++ b/rust/src/api/history.rs
@@ -28,13 +28,17 @@ impl TxHistory {
     }
 
     #[flutter_rust_bridge::frb(sync)]
-    pub fn decode(encoded_history: String) -> Self {
-        serde_json::from_str(&encoded_history).unwrap()
+    pub fn decode(encoded_history: String) -> Result<Self> {
+        let decoded: Vec<ApiRecordedTransaction> = serde_json::from_str(&encoded_history)?;
+
+        Ok(Self(decoded.into_iter().map(Into::into).collect()))
     }
 
     #[flutter_rust_bridge::frb(sync)]
-    pub fn encode(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    pub fn encode(&self) -> Result<String> {
+        let encoded = self.to_api_transactions();
+
+        Ok(serde_json::to_string(&encoded)?)
     }
 
     #[flutter_rust_bridge::frb(sync)]

--- a/rust/src/api/outputs.rs
+++ b/rust/src/api/outputs.rs
@@ -36,13 +36,27 @@ impl OwnedOutputs {
     }
 
     #[flutter_rust_bridge::frb(sync)]
-    pub fn decode(encoded_outputs: String) -> Self {
-        serde_json::from_str(&encoded_outputs).unwrap()
+    pub fn decode(encoded_outputs: String) -> Result<Self> {
+        let decoded: HashMap<String, ApiOwnedOutput> = serde_json::from_str(&encoded_outputs)?;
+
+        let mut res: HashMap<OutPoint, OwnedOutput> = HashMap::new();
+
+        for (outpoint, output) in decoded.into_iter() {
+            res.insert(OutPoint::from_str(&outpoint)?, output.into());
+        }
+
+        Ok(Self(res))
     }
 
     #[flutter_rust_bridge::frb(sync)]
-    pub fn encode(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    pub fn encode(&self) -> Result<String> {
+        let mut encoded: HashMap<String, ApiOwnedOutput> = HashMap::new();
+
+        for (outpoint, output) in self.0.iter() {
+            encoded.insert(outpoint.to_string(), output.clone().into());
+        }
+
+        Ok(serde_json::to_string(&encoded)?)
     }
 
     #[flutter_rust_bridge::frb(sync)]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -592,12 +592,12 @@ fn wire__crate__api__outputs__OwnedOutputs_decode_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_encoded_outputs = <String>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok(crate::api::outputs::OwnedOutputs::decode(
-                    api_encoded_outputs,
-                ))?;
-                Ok(output_ok)
-            })())
+            transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                (move || {
+                    let output_ok = crate::api::outputs::OwnedOutputs::decode(api_encoded_outputs)?;
+                    Ok(output_ok)
+                })(),
+            )
         },
     )
 }
@@ -655,26 +655,26 @@ fn wire__crate__api__outputs__OwnedOutputs_encode_impl(
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<OwnedOutputs>,
             >>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, false,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
-                        _ => unreachable!(),
+            transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                (move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
                     }
-                }
-                let api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok(crate::api::outputs::OwnedOutputs::encode(
-                    &*api_that_guard,
-                ))?;
-                Ok(output_ok)
-            })())
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = crate::api::outputs::OwnedOutputs::encode(&*api_that_guard)?;
+                    Ok(output_ok)
+                })(),
+            )
         },
     )
 }
@@ -2099,12 +2099,12 @@ fn wire__crate__api__history__TxHistory_decode_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_encoded_history = <String>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let output_ok = Result::<_, ()>::Ok(crate::api::history::TxHistory::decode(
-                    api_encoded_history,
-                ))?;
-                Ok(output_ok)
-            })())
+            transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                (move || {
+                    let output_ok = crate::api::history::TxHistory::decode(api_encoded_history)?;
+                    Ok(output_ok)
+                })(),
+            )
         },
     )
 }
@@ -2162,25 +2162,26 @@ fn wire__crate__api__history__TxHistory_encode_impl(
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TxHistory>,
             >>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, false,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
-                        _ => unreachable!(),
+            transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                (move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
                     }
-                }
-                let api_that_guard = api_that_guard.unwrap();
-                let output_ok =
-                    Result::<_, ()>::Ok(crate::api::history::TxHistory::encode(&*api_that_guard))?;
-                Ok(output_ok)
-            })())
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = crate::api::history::TxHistory::encode(&*api_that_guard)?;
+                    Ok(output_ok)
+                })(),
+            )
         },
     )
 }


### PR DESCRIPTION
We used the serde serialize/deserialize from spdk before, but this means that the struct format of a dependency affects whether or not we can decode/encode our wallet. We should decouple this dependency by first decoding to our own native struct type, and then converting into the spdk struct type.

Required for #209 