### PR TITLE
Choose recipient screen: reset error text on selecting text field

### DIFF
--- a/lib/screens/home/wallet/spend/choose_recipient.dart
+++ b/lib/screens/home/wallet/spend/choose_recipient.dart
@@ -106,6 +106,7 @@ class ChooseRecipientScreenState extends State<ChooseRecipientScreen> {
                     height: 20.0,
                   ),
                   TextField(
+                    onTap: () => setState(() => _addressErrorText = null),
                     style: BitcoinTextStyle.body4(Bitcoin.black),
                     controller: addressController,
                     keyboardType: TextInputType.emailAddress,


### PR DESCRIPTION
After a user gets an error message related to the address input field, they will change the address field. So we need to reset the state of the error message when a user attempts to make a change.