### PR TITLE
Retry fetching block height on timeout

### DIFF
--- a/rust/src/api/chain.rs
+++ b/rust/src/api/chain.rs
@@ -1,9 +1,30 @@
+use std::time::Duration;
+
+use log::warn;
 use spdk::{bitcoin::Network, BlindbitBackend, BlindbitClient, ChainBackend};
+use tokio::time::sleep;
 
 pub async fn get_chain_height(blindbit_url: String) -> anyhow::Result<u32> {
     let backend = BlindbitBackend::new(blindbit_url)?;
 
-    Ok(backend.block_height().await?.to_consensus_u32())
+    match backend.block_height().await {
+        Ok(res) => Ok(res.to_consensus_u32()),
+        Err(e) => {
+            if e.root_cause()
+                .to_string()
+                .starts_with("operation timed out")
+            {
+                warn!("Got timeout fetching block height, retrying");
+
+                // sleep for 1 second
+                sleep(Duration::from_millis(1000)).await;
+
+                Ok(backend.block_height().await?.to_consensus_u32())
+            } else {
+                Err(e)
+            }
+        }
+    }
 }
 
 pub async fn check_network(blindbit_url: String, network: String) -> anyhow::Result<bool> {


### PR DESCRIPTION
Sometimes we get a timeout when fetching the block height, and immediately show a connection error to the screen. This commit makes it so we retry once, and only throw an error if we fail a second time.

Closes #236