### PR TITLE
Lower dust limit to 600 sats

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,7 +17,7 @@ const int defaultRegtestBirthday = 80000;
 // default dust limit. this is used in syncing, as well as sending
 // for syncing, amounts < dust limit will be ignored
 // for sending, the user needs to send a minimum of >= dust
-const int defaultDustLimit = 1000;
+const int defaultDustLimit = 600;
 
 // default fiat currency
 const FiatCurrency defaultCurrency = FiatCurrency.usd;


### PR DESCRIPTION
Some users seem to be testing out Dana with small utxos (size of 800-1000 sats). These weren't picked up by Dana because we have a dust limit of 1000 sats.

We lower the dust limit to 600. As long as the limit is above 546, this shouldn't have too big of a performance impact.