### PR TITLE
Fix wallet not confirming spent outputs that we haven't spent ourselves

### DIFF
--- a/lib/generated/rust/api/history.dart
+++ b/lib/generated/rust/api/history.dart
@@ -5,10 +5,11 @@
 
 import '../frb_generated.dart';
 import '../stream.dart';
+import 'outputs.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'structs.dart';
 
-// These functions are ignored because they are not marked as `pub`: `check_is_self_send`, `confirm_recorded_outgoing_transaction`, `record_incoming_transaction`, `record_outgoing_transaction`
+// These functions are ignored because they are not marked as `pub`: `check_is_self_send`, `confirm_recorded_outgoing_transaction`, `record_incoming_transaction`, `record_outgoing_transaction`, `record_unknown_outgoing_transaction`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<TxHistory>>
@@ -31,7 +32,8 @@ abstract class TxHistory implements RustOpaqueInterface {
 
   ApiAmount getUnconfirmedChange();
 
-  void processStateUpdate({required StateUpdate update});
+  void processStateUpdate(
+      {required StateUpdate update, required OwnedOutputs ownedOutputs});
 
   void resetToHeight({required int height});
 

--- a/lib/generated/rust/api/outputs.dart
+++ b/lib/generated/rust/api/outputs.dart
@@ -9,7 +9,7 @@ import '../stream.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'structs.dart';
 
-// These functions are ignored because they are not marked as `pub`: `mark_mined`, `mark_spent`, `revert_spent_status`, `to_inner`
+// These functions are ignored because they are not marked as `pub`: `get`, `mark_mined`, `mark_spent`, `revert_spent_status`, `to_inner`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<OwnedOutPoints>>

--- a/lib/generated/rust/api/structs.dart
+++ b/lib/generated/rust/api/structs.dart
@@ -9,7 +9,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'structs.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `try_from`
 
 class ApiAmount {
   final BigInt field0;
@@ -129,6 +129,9 @@ sealed class ApiRecordedTransaction with _$ApiRecordedTransaction {
   const factory ApiRecordedTransaction.outgoing(
     ApiRecordedTransactionOutgoing field0,
   ) = ApiRecordedTransaction_Outgoing;
+  const factory ApiRecordedTransaction.unknownOutgoing(
+    ApiRecordedTransactionUnknownOutgoing field0,
+  ) = ApiRecordedTransaction_UnknownOutgoing;
 }
 
 class ApiRecordedTransactionIncoming {
@@ -207,6 +210,36 @@ class ApiRecordedTransactionOutgoing {
           confirmedAt == other.confirmedAt &&
           change == other.change &&
           fee == other.fee;
+}
+
+class ApiRecordedTransactionUnknownOutgoing {
+  final ApiAmount amount;
+  final int confirmedAt;
+  final List<String> spentOutpoints;
+
+  const ApiRecordedTransactionUnknownOutgoing({
+    required this.amount,
+    required this.confirmedAt,
+    required this.spentOutpoints,
+  });
+
+  String toString() => RustLib.instance.api
+          .crateApiStructsApiRecordedTransactionUnknownOutgoingToString(
+        that: this,
+      );
+
+  @override
+  int get hashCode =>
+      amount.hashCode ^ confirmedAt.hashCode ^ spentOutpoints.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ApiRecordedTransactionUnknownOutgoing &&
+          runtimeType == other.runtimeType &&
+          amount == other.amount &&
+          confirmedAt == other.confirmedAt &&
+          spentOutpoints == other.spentOutpoints;
 }
 
 class ApiSilentPaymentUnsignedTransaction {

--- a/lib/generated/rust/api/structs.freezed.dart
+++ b/lib/generated/rust/api/structs.freezed.dart
@@ -492,18 +492,24 @@ mixin _$ApiRecordedTransaction {
   TResult when<TResult extends Object?>({
     required TResult Function(ApiRecordedTransactionIncoming field0) incoming,
     required TResult Function(ApiRecordedTransactionOutgoing field0) outgoing,
+    required TResult Function(ApiRecordedTransactionUnknownOutgoing field0)
+        unknownOutgoing,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult? Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult? Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -511,18 +517,24 @@ mixin _$ApiRecordedTransaction {
   TResult map<TResult extends Object?>({
     required TResult Function(ApiRecordedTransaction_Incoming value) incoming,
     required TResult Function(ApiRecordedTransaction_Outgoing value) outgoing,
+    required TResult Function(ApiRecordedTransaction_UnknownOutgoing value)
+        unknownOutgoing,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult? Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult? Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -619,6 +631,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult when<TResult extends Object?>({
     required TResult Function(ApiRecordedTransactionIncoming field0) incoming,
     required TResult Function(ApiRecordedTransactionOutgoing field0) outgoing,
+    required TResult Function(ApiRecordedTransactionUnknownOutgoing field0)
+        unknownOutgoing,
   }) {
     return incoming(field0);
   }
@@ -628,6 +642,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult? Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult? Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
   }) {
     return incoming?.call(field0);
   }
@@ -637,6 +653,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
     required TResult orElse(),
   }) {
     if (incoming != null) {
@@ -650,6 +668,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult map<TResult extends Object?>({
     required TResult Function(ApiRecordedTransaction_Incoming value) incoming,
     required TResult Function(ApiRecordedTransaction_Outgoing value) outgoing,
+    required TResult Function(ApiRecordedTransaction_UnknownOutgoing value)
+        unknownOutgoing,
   }) {
     return incoming(this);
   }
@@ -659,6 +679,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult? Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult? Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
   }) {
     return incoming?.call(this);
   }
@@ -668,6 +690,8 @@ class _$ApiRecordedTransaction_IncomingImpl
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
     required TResult orElse(),
   }) {
     if (incoming != null) {
@@ -763,6 +787,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult when<TResult extends Object?>({
     required TResult Function(ApiRecordedTransactionIncoming field0) incoming,
     required TResult Function(ApiRecordedTransactionOutgoing field0) outgoing,
+    required TResult Function(ApiRecordedTransactionUnknownOutgoing field0)
+        unknownOutgoing,
   }) {
     return outgoing(field0);
   }
@@ -772,6 +798,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult? Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult? Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
   }) {
     return outgoing?.call(field0);
   }
@@ -781,6 +809,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ApiRecordedTransactionIncoming field0)? incoming,
     TResult Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
     required TResult orElse(),
   }) {
     if (outgoing != null) {
@@ -794,6 +824,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult map<TResult extends Object?>({
     required TResult Function(ApiRecordedTransaction_Incoming value) incoming,
     required TResult Function(ApiRecordedTransaction_Outgoing value) outgoing,
+    required TResult Function(ApiRecordedTransaction_UnknownOutgoing value)
+        unknownOutgoing,
   }) {
     return outgoing(this);
   }
@@ -803,6 +835,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult? Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult? Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
   }) {
     return outgoing?.call(this);
   }
@@ -812,6 +846,8 @@ class _$ApiRecordedTransaction_OutgoingImpl
   TResult maybeMap<TResult extends Object?>({
     TResult Function(ApiRecordedTransaction_Incoming value)? incoming,
     TResult Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
     required TResult orElse(),
   }) {
     if (outgoing != null) {
@@ -832,5 +868,163 @@ abstract class ApiRecordedTransaction_Outgoing extends ApiRecordedTransaction {
   @JsonKey(ignore: true)
   _$$ApiRecordedTransaction_OutgoingImplCopyWith<
           _$ApiRecordedTransaction_OutgoingImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ApiRecordedTransaction_UnknownOutgoingImplCopyWith<$Res> {
+  factory _$$ApiRecordedTransaction_UnknownOutgoingImplCopyWith(
+          _$ApiRecordedTransaction_UnknownOutgoingImpl value,
+          $Res Function(_$ApiRecordedTransaction_UnknownOutgoingImpl) then) =
+      __$$ApiRecordedTransaction_UnknownOutgoingImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ApiRecordedTransactionUnknownOutgoing field0});
+}
+
+/// @nodoc
+class __$$ApiRecordedTransaction_UnknownOutgoingImplCopyWithImpl<$Res>
+    extends _$ApiRecordedTransactionCopyWithImpl<$Res,
+        _$ApiRecordedTransaction_UnknownOutgoingImpl>
+    implements _$$ApiRecordedTransaction_UnknownOutgoingImplCopyWith<$Res> {
+  __$$ApiRecordedTransaction_UnknownOutgoingImplCopyWithImpl(
+      _$ApiRecordedTransaction_UnknownOutgoingImpl _value,
+      $Res Function(_$ApiRecordedTransaction_UnknownOutgoingImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(_$ApiRecordedTransaction_UnknownOutgoingImpl(
+      null == field0
+          ? _value.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as ApiRecordedTransactionUnknownOutgoing,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ApiRecordedTransaction_UnknownOutgoingImpl
+    extends ApiRecordedTransaction_UnknownOutgoing {
+  const _$ApiRecordedTransaction_UnknownOutgoingImpl(this.field0) : super._();
+
+  @override
+  final ApiRecordedTransactionUnknownOutgoing field0;
+
+  @override
+  String toString() {
+    return 'ApiRecordedTransaction.unknownOutgoing(field0: $field0)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiRecordedTransaction_UnknownOutgoingImpl &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiRecordedTransaction_UnknownOutgoingImplCopyWith<
+          _$ApiRecordedTransaction_UnknownOutgoingImpl>
+      get copyWith =>
+          __$$ApiRecordedTransaction_UnknownOutgoingImplCopyWithImpl<
+              _$ApiRecordedTransaction_UnknownOutgoingImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ApiRecordedTransactionIncoming field0) incoming,
+    required TResult Function(ApiRecordedTransactionOutgoing field0) outgoing,
+    required TResult Function(ApiRecordedTransactionUnknownOutgoing field0)
+        unknownOutgoing,
+  }) {
+    return unknownOutgoing(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ApiRecordedTransactionIncoming field0)? incoming,
+    TResult? Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult? Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
+  }) {
+    return unknownOutgoing?.call(field0);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ApiRecordedTransactionIncoming field0)? incoming,
+    TResult Function(ApiRecordedTransactionOutgoing field0)? outgoing,
+    TResult Function(ApiRecordedTransactionUnknownOutgoing field0)?
+        unknownOutgoing,
+    required TResult orElse(),
+  }) {
+    if (unknownOutgoing != null) {
+      return unknownOutgoing(field0);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ApiRecordedTransaction_Incoming value) incoming,
+    required TResult Function(ApiRecordedTransaction_Outgoing value) outgoing,
+    required TResult Function(ApiRecordedTransaction_UnknownOutgoing value)
+        unknownOutgoing,
+  }) {
+    return unknownOutgoing(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ApiRecordedTransaction_Incoming value)? incoming,
+    TResult? Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult? Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
+  }) {
+    return unknownOutgoing?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ApiRecordedTransaction_Incoming value)? incoming,
+    TResult Function(ApiRecordedTransaction_Outgoing value)? outgoing,
+    TResult Function(ApiRecordedTransaction_UnknownOutgoing value)?
+        unknownOutgoing,
+    required TResult orElse(),
+  }) {
+    if (unknownOutgoing != null) {
+      return unknownOutgoing(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ApiRecordedTransaction_UnknownOutgoing
+    extends ApiRecordedTransaction {
+  const factory ApiRecordedTransaction_UnknownOutgoing(
+          final ApiRecordedTransactionUnknownOutgoing field0) =
+      _$ApiRecordedTransaction_UnknownOutgoingImpl;
+  const ApiRecordedTransaction_UnknownOutgoing._() : super._();
+
+  @override
+  ApiRecordedTransactionUnknownOutgoing get field0;
+  @JsonKey(ignore: true)
+  _$$ApiRecordedTransaction_UnknownOutgoingImplCopyWith<
+          _$ApiRecordedTransaction_UnknownOutgoingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/generated/rust/frb_generated.dart
+++ b/lib/generated/rust/frb_generated.dart
@@ -81,7 +81,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1924410111;
+  int get rustContentHash => 1421572005;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -239,7 +239,9 @@ abstract class RustLibApi extends BaseApi {
       {required TxHistory that});
 
   void crateApiHistoryTxHistoryProcessStateUpdate(
-      {required TxHistory that, required StateUpdate update});
+      {required TxHistory that,
+      required StateUpdate update,
+      required OwnedOutputs ownedOutputs});
 
   void crateApiHistoryTxHistoryResetToHeight(
       {required TxHistory that, required int height});
@@ -337,6 +339,9 @@ abstract class RustLibApi extends BaseApi {
 
   ApiAmount crateApiStructsApiRecordedTransactionOutgoingTotalOutgoing(
       {required ApiRecordedTransactionOutgoing that});
+
+  String crateApiStructsApiRecordedTransactionUnknownOutgoingToString(
+      {required ApiRecordedTransactionUnknownOutgoing that});
 
   ApiAmount crateApiStructsApiSilentPaymentUnsignedTransactionGetChangeAmount(
       {required ApiSilentPaymentUnsignedTransaction that,
@@ -1791,7 +1796,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   void crateApiHistoryTxHistoryProcessStateUpdate(
-      {required TxHistory that, required StateUpdate update}) {
+      {required TxHistory that,
+      required StateUpdate update,
+      required OwnedOutputs ownedOutputs}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
@@ -1799,6 +1806,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that, serializer);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStateUpdate(
             update, serializer);
+        sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOwnedOutputs(
+            ownedOutputs, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
       },
       codec: SseCodec(
@@ -1806,7 +1815,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiHistoryTxHistoryProcessStateUpdateConstMeta,
-      argValues: [that, update],
+      argValues: [that, update, ownedOutputs],
       apiImpl: this,
     ));
   }
@@ -1814,7 +1823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiHistoryTxHistoryProcessStateUpdateConstMeta =>
       const TaskConstMeta(
         debugName: "TxHistory_process_state_update",
-        argNames: ["that", "update"],
+        argNames: ["that", "update", "ownedOutputs"],
       );
 
   @override
@@ -2729,6 +2738,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
+  String crateApiStructsApiRecordedTransactionUnknownOutgoingToString(
+      {required ApiRecordedTransactionUnknownOutgoing that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+            that, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: null,
+      ),
+      constMeta:
+          kCrateApiStructsApiRecordedTransactionUnknownOutgoingToStringConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiStructsApiRecordedTransactionUnknownOutgoingToStringConstMeta =>
+          const TaskConstMeta(
+            debugName: "api_recorded_transaction_unknown_outgoing_to_string",
+            argNames: ["that"],
+          );
+
+  @override
   ApiAmount crateApiStructsApiSilentPaymentUnsignedTransactionGetChangeAmount(
       {required ApiSilentPaymentUnsignedTransaction that,
       required String changeAddress}) {
@@ -2738,7 +2775,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(
             that, serializer);
         sse_encode_String(changeAddress, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_api_amount,
@@ -2767,7 +2804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_api_amount,
@@ -2798,7 +2835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(
             that, serializer);
         sse_encode_String(changeAddress, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_api_recipient,
@@ -2828,7 +2865,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(
             that, serializer);
         sse_encode_String(changeAddress, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_api_amount,
@@ -2858,7 +2895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(blindbitUrl, serializer);
         sse_encode_String(network, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 86, port: port_);
+            funcId: 87, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2885,7 +2922,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_StreamSink_log_entry_Sse(s, serializer);
         sse_encode_log_level(level, serializer);
         sse_encode_bool(logDependencies, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2911,7 +2948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_scan_progress_Sse(s, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2938,7 +2975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerStateUpdate_Sse(
             s, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2964,7 +3001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(encoded, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_encrypted_dana_backup,
@@ -2990,7 +3027,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_encrypted_dana_backup(that, serializer);
         sse_encode_String(password, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -3016,7 +3053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_encrypted_dana_backup(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3042,7 +3079,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(ivBase64, serializer);
         sse_encode_String(contentBase64, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_encrypted_dana_backup,
@@ -3066,7 +3103,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_fiat_currency(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3090,7 +3127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_fiat_currency(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -3114,7 +3151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_fiat_currency(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3139,7 +3176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(blindbitUrl, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 97, port: port_);
+            funcId: 98, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -3163,7 +3200,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 98, port: port_);
+            funcId: 99, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3188,7 +3225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_String(blindbitUrl, serializer);
         sse_encode_opt_box_autoadd_u_32(dustLimit, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_settings_backup,
@@ -3214,7 +3251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(address, serializer);
         sse_encode_String(network, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3695,6 +3732,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return ApiRecordedTransaction_Outgoing(
           dco_decode_box_autoadd_api_recorded_transaction_outgoing(raw[1]),
         );
+      case 2:
+        return ApiRecordedTransaction_UnknownOutgoing(
+          dco_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+              raw[1]),
+        );
       default:
         throw Exception("unreachable");
     }
@@ -3728,6 +3770,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       confirmedAt: dco_decode_opt_box_autoadd_u_32(arr[3]),
       change: dco_decode_api_amount(arr[4]),
       fee: dco_decode_api_amount(arr[5]),
+    );
+  }
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_api_recorded_transaction_unknown_outgoing(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return ApiRecordedTransactionUnknownOutgoing(
+      amount: dco_decode_api_amount(arr[0]),
+      confirmedAt: dco_decode_u_32(arr[1]),
+      spentOutpoints: dco_decode_list_String(arr[2]),
     );
   }
 
@@ -3789,6 +3845,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_box_autoadd_api_recorded_transaction_outgoing(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_api_recorded_transaction_outgoing(raw);
+  }
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+          dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_api_recorded_transaction_unknown_outgoing(raw);
   }
 
   @protected
@@ -4482,6 +4546,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             sse_decode_box_autoadd_api_recorded_transaction_outgoing(
                 deserializer);
         return ApiRecordedTransaction_Outgoing(var_field0);
+      case 2:
+        var var_field0 =
+            sse_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+                deserializer);
+        return ApiRecordedTransaction_UnknownOutgoing(var_field0);
       default:
         throw UnimplementedError('');
     }
@@ -4515,6 +4584,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         confirmedAt: var_confirmedAt,
         change: var_change,
         fee: var_fee);
+  }
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_api_recorded_transaction_unknown_outgoing(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_amount = sse_decode_api_amount(deserializer);
+    var var_confirmedAt = sse_decode_u_32(deserializer);
+    var var_spentOutpoints = sse_decode_list_String(deserializer);
+    return ApiRecordedTransactionUnknownOutgoing(
+        amount: var_amount,
+        confirmedAt: var_confirmedAt,
+        spentOutpoints: var_spentOutpoints);
   }
 
   @protected
@@ -4580,6 +4663,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_api_recorded_transaction_outgoing(deserializer));
+  }
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+          SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_api_recorded_transaction_unknown_outgoing(deserializer));
   }
 
   @protected
@@ -5314,6 +5405,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(1, serializer);
         sse_encode_box_autoadd_api_recorded_transaction_outgoing(
             field0, serializer);
+      case ApiRecordedTransaction_UnknownOutgoing(field0: final field0):
+        sse_encode_i_32(2, serializer);
+        sse_encode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+            field0, serializer);
     }
   }
 
@@ -5336,6 +5431,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_32(self.confirmedAt, serializer);
     sse_encode_api_amount(self.change, serializer);
     sse_encode_api_amount(self.fee, serializer);
+  }
+
+  @protected
+  void sse_encode_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_api_amount(self.amount, serializer);
+    sse_encode_u_32(self.confirmedAt, serializer);
+    sse_encode_list_String(self.spentOutpoints, serializer);
   }
 
   @protected
@@ -5393,6 +5497,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       ApiRecordedTransactionOutgoing self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_api_recorded_transaction_outgoing(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_api_recorded_transaction_unknown_outgoing(self, serializer);
   }
 
   @protected
@@ -6003,8 +6114,10 @@ class TxHistoryImpl extends RustOpaque implements TxHistory {
         that: this,
       );
 
-  void processStateUpdate({required StateUpdate update}) => RustLib.instance.api
-      .crateApiHistoryTxHistoryProcessStateUpdate(that: this, update: update);
+  void processStateUpdate(
+          {required StateUpdate update, required OwnedOutputs ownedOutputs}) =>
+      RustLib.instance.api.crateApiHistoryTxHistoryProcessStateUpdate(
+          that: this, update: update, ownedOutputs: ownedOutputs);
 
   void resetToHeight({required int height}) => RustLib.instance.api
       .crateApiHistoryTxHistoryResetToHeight(that: this, height: height);

--- a/lib/generated/rust/frb_generated.io.dart
+++ b/lib/generated/rust/frb_generated.io.dart
@@ -281,6 +281,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       dynamic raw);
 
   @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_api_recorded_transaction_unknown_outgoing(dynamic raw);
+
+  @protected
   ApiSilentPaymentUnsignedTransaction
       dco_decode_api_silent_payment_unsigned_transaction(dynamic raw);
 
@@ -307,6 +311,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   ApiRecordedTransactionOutgoing
       dco_decode_box_autoadd_api_recorded_transaction_outgoing(dynamic raw);
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+          dynamic raw);
 
   @protected
   ApiSilentPaymentUnsignedTransaction
@@ -632,6 +641,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_api_recorded_transaction_unknown_outgoing(
+          SseDeserializer deserializer);
+
+  @protected
   ApiSilentPaymentUnsignedTransaction
       sse_decode_api_silent_payment_unsigned_transaction(
           SseDeserializer deserializer);
@@ -660,6 +674,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   ApiRecordedTransactionOutgoing
       sse_decode_box_autoadd_api_recorded_transaction_outgoing(
+          SseDeserializer deserializer);
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
           SseDeserializer deserializer);
 
   @protected
@@ -993,6 +1012,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ApiRecordedTransactionOutgoing self, SseSerializer serializer);
 
   @protected
+  void sse_encode_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer);
+
+  @protected
   void sse_encode_api_silent_payment_unsigned_transaction(
       ApiSilentPaymentUnsignedTransaction self, SseSerializer serializer);
 
@@ -1020,6 +1043,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_api_recorded_transaction_outgoing(
       ApiRecordedTransactionOutgoing self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(

--- a/lib/generated/rust/frb_generated.web.dart
+++ b/lib/generated/rust/frb_generated.web.dart
@@ -283,6 +283,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       dynamic raw);
 
   @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_api_recorded_transaction_unknown_outgoing(dynamic raw);
+
+  @protected
   ApiSilentPaymentUnsignedTransaction
       dco_decode_api_silent_payment_unsigned_transaction(dynamic raw);
 
@@ -309,6 +313,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   ApiRecordedTransactionOutgoing
       dco_decode_box_autoadd_api_recorded_transaction_outgoing(dynamic raw);
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      dco_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+          dynamic raw);
 
   @protected
   ApiSilentPaymentUnsignedTransaction
@@ -634,6 +643,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_api_recorded_transaction_unknown_outgoing(
+          SseDeserializer deserializer);
+
+  @protected
   ApiSilentPaymentUnsignedTransaction
       sse_decode_api_silent_payment_unsigned_transaction(
           SseDeserializer deserializer);
@@ -662,6 +676,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   ApiRecordedTransactionOutgoing
       sse_decode_box_autoadd_api_recorded_transaction_outgoing(
+          SseDeserializer deserializer);
+
+  @protected
+  ApiRecordedTransactionUnknownOutgoing
+      sse_decode_box_autoadd_api_recorded_transaction_unknown_outgoing(
           SseDeserializer deserializer);
 
   @protected
@@ -995,6 +1014,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ApiRecordedTransactionOutgoing self, SseSerializer serializer);
 
   @protected
+  void sse_encode_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer);
+
+  @protected
   void sse_encode_api_silent_payment_unsigned_transaction(
       ApiSilentPaymentUnsignedTransaction self, SseSerializer serializer);
 
@@ -1022,6 +1045,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_api_recorded_transaction_outgoing(
       ApiRecordedTransactionOutgoing self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_api_recorded_transaction_unknown_outgoing(
+      ApiRecordedTransactionUnknownOutgoing self, SseSerializer serializer);
 
   @protected
   void sse_encode_box_autoadd_api_silent_payment_unsigned_transaction(

--- a/lib/screens/home/wallet/wallet.dart
+++ b/lib/screens/home/wallet/wallet.dart
@@ -243,6 +243,21 @@ class WalletScreenState extends State<WalletScreen> {
         image = Image(
             image: const AssetImage("icons/send.png", package: "bitcoin_ui"),
             color: Bitcoin.neutral3Dark);
+
+      case ApiRecordedTransaction_UnknownOutgoing(:final field0):
+        recipient = "Unknown";
+        date = field0.confirmedAt.toString();
+        color = Bitcoin.red;
+        amount = hideAmount ? hideAmountFormat : field0.amount.displayBtc();
+        amountprefix = '-';
+        amountFiat = hideAmount
+            ? hideAmountFormat
+            : exchangeRate.displayFiat(field0.amount);
+        title = 'Parially recovered outgoing transaction';
+        text = field0.toString();
+        image = Image(
+            image: const AssetImage("icons/send.png", package: "bitcoin_ui"),
+            color: Bitcoin.neutral3Dark);
     }
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 4),

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -46,7 +46,7 @@ class WalletState extends ChangeNotifier {
     scanResultSubscription = createScanResultStream().listen(((event) async {
       // process update
       lastScan = event.getHeight();
-      txHistory.processStateUpdate(update: event);
+      txHistory.processStateUpdate(update: event, ownedOutputs: ownedOutputs);
       ownedOutputs.processStateUpdate(update: event);
 
       // save updates to storage

--- a/rust/src/api/outputs.rs
+++ b/rust/src/api/outputs.rs
@@ -205,4 +205,8 @@ impl OwnedOutputs {
             ))),
         }
     }
+
+    pub(crate) fn get(&self, key: &OutPoint) -> Option<&OwnedOutput> {
+        self.0.get(key)
+    }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1924410111;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1421572005;
 
 // Section: executor
 
@@ -2260,11 +2260,15 @@ fn wire__crate__api__history__TxHistory_process_state_update_impl(
             let api_update = <RustOpaqueMoi<
                 flutter_rust_bridge::for_generated::RustAutoOpaqueInner<StateUpdate>,
             >>::sse_decode(&mut deserializer);
+            let api_owned_outputs = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<OwnedOutputs>,
+            >>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                 (move || {
                     let mut api_that_guard = None;
                     let mut api_update_guard = None;
+                    let mut api_owned_outputs_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
                             flutter_rust_bridge::for_generated::LockableOrderInfo::new(
@@ -2275,19 +2279,30 @@ fn wire__crate__api__history__TxHistory_process_state_update_impl(
                                 1,
                                 false,
                             ),
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_owned_outputs,
+                                2,
+                                false,
+                            ),
                         ]);
                     for i in decode_indices_ {
                         match i {
                             0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
                             1 => api_update_guard = Some(api_update.lockable_decode_sync_ref()),
+                            2 => {
+                                api_owned_outputs_guard =
+                                    Some(api_owned_outputs.lockable_decode_sync_ref())
+                            }
                             _ => unreachable!(),
                         }
                     }
                     let mut api_that_guard = api_that_guard.unwrap();
                     let api_update_guard = api_update_guard.unwrap();
+                    let api_owned_outputs_guard = api_owned_outputs_guard.unwrap();
                     let output_ok = crate::api::history::TxHistory::process_state_update(
                         &mut *api_that_guard,
                         &*api_update_guard,
+                        &*api_owned_outputs_guard,
                     )?;
                     Ok(output_ok)
                 })(),
@@ -3731,6 +3746,42 @@ fn wire__crate__api__structs__api_recorded_transaction_outgoing_total_outgoing_i
         },
     )
 }
+fn wire__crate__api__structs__api_recorded_transaction_unknown_outgoing_to_string_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "api_recorded_transaction_unknown_outgoing_to_string",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::structs::ApiRecordedTransactionUnknownOutgoing>::sse_decode(
+                &mut deserializer,
+            );
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::structs::ApiRecordedTransactionUnknownOutgoing::to_string(
+                        &api_that,
+                    ),
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_change_amount_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -4761,6 +4812,13 @@ impl SseDecode for crate::api::structs::ApiRecordedTransaction {
                     <crate::api::structs::ApiRecordedTransactionOutgoing>::sse_decode(deserializer);
                 return crate::api::structs::ApiRecordedTransaction::Outgoing(var_field0);
             }
+            2 => {
+                let mut var_field0 =
+                    <crate::api::structs::ApiRecordedTransactionUnknownOutgoing>::sse_decode(
+                        deserializer,
+                    );
+                return crate::api::structs::ApiRecordedTransaction::UnknownOutgoing(var_field0);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -4798,6 +4856,20 @@ impl SseDecode for crate::api::structs::ApiRecordedTransactionOutgoing {
             confirmed_at: var_confirmedAt,
             change: var_change,
             fee: var_fee,
+        };
+    }
+}
+
+impl SseDecode for crate::api::structs::ApiRecordedTransactionUnknownOutgoing {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_amount = <crate::api::structs::ApiAmount>::sse_decode(deserializer);
+        let mut var_confirmedAt = <u32>::sse_decode(deserializer);
+        let mut var_spentOutpoints = <Vec<String>>::sse_decode(deserializer);
+        return crate::api::structs::ApiRecordedTransactionUnknownOutgoing {
+            amount: var_amount,
+            confirmed_at: var_confirmedAt,
+            spent_outpoints: var_spentOutpoints,
         };
     }
 }
@@ -5161,9 +5233,9 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__wallet__SpWallet_scan_to_tip_impl(port, ptr, rust_vec_len, data_len)
         }
         75 => wire__crate__api__structs__api_amount_default_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__chain__check_network_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__chain__get_chain_height_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__chain__check_network_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__chain__get_chain_height_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5253,22 +5325,23 @@ fn pde_ffi_dispatcher_sync_impl(
 79 => wire__crate__api__structs__api_recorded_transaction_incoming_to_string_impl(ptr, rust_vec_len, data_len),
 80 => wire__crate__api__structs__api_recorded_transaction_outgoing_to_string_impl(ptr, rust_vec_len, data_len),
 81 => wire__crate__api__structs__api_recorded_transaction_outgoing_total_outgoing_impl(ptr, rust_vec_len, data_len),
-82 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_change_amount_impl(ptr, rust_vec_len, data_len),
-83 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_fee_amount_impl(ptr, rust_vec_len, data_len),
-84 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_recipients_impl(ptr, rust_vec_len, data_len),
-85 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_send_amount_impl(ptr, rust_vec_len, data_len),
-87 => wire__crate__api__stream__create_log_stream_impl(ptr, rust_vec_len, data_len),
-88 => wire__crate__api__stream__create_scan_progress_stream_impl(ptr, rust_vec_len, data_len),
-89 => wire__crate__api__stream__create_scan_result_stream_impl(ptr, rust_vec_len, data_len),
-90 => wire__crate__api__backup__encrypted_dana_backup_decode_impl(ptr, rust_vec_len, data_len),
-91 => wire__crate__api__backup__encrypted_dana_backup_decrypt_impl(ptr, rust_vec_len, data_len),
-92 => wire__crate__api__backup__encrypted_dana_backup_encode_impl(ptr, rust_vec_len, data_len),
-93 => wire__crate__api__backup__encrypted_dana_backup_new_impl(ptr, rust_vec_len, data_len),
-94 => wire__crate__api__structs__fiat_currency_display_name_impl(ptr, rust_vec_len, data_len),
-95 => wire__crate__api__structs__fiat_currency_minor_units_impl(ptr, rust_vec_len, data_len),
-96 => wire__crate__api__structs__fiat_currency_symbol_impl(ptr, rust_vec_len, data_len),
-99 => wire__crate__api__backup__settings_backup_new_impl(ptr, rust_vec_len, data_len),
-100 => wire__crate__api__validate__validate_address_with_network_impl(ptr, rust_vec_len, data_len),
+82 => wire__crate__api__structs__api_recorded_transaction_unknown_outgoing_to_string_impl(ptr, rust_vec_len, data_len),
+83 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_change_amount_impl(ptr, rust_vec_len, data_len),
+84 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_fee_amount_impl(ptr, rust_vec_len, data_len),
+85 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_recipients_impl(ptr, rust_vec_len, data_len),
+86 => wire__crate__api__structs__api_silent_payment_unsigned_transaction_get_send_amount_impl(ptr, rust_vec_len, data_len),
+88 => wire__crate__api__stream__create_log_stream_impl(ptr, rust_vec_len, data_len),
+89 => wire__crate__api__stream__create_scan_progress_stream_impl(ptr, rust_vec_len, data_len),
+90 => wire__crate__api__stream__create_scan_result_stream_impl(ptr, rust_vec_len, data_len),
+91 => wire__crate__api__backup__encrypted_dana_backup_decode_impl(ptr, rust_vec_len, data_len),
+92 => wire__crate__api__backup__encrypted_dana_backup_decrypt_impl(ptr, rust_vec_len, data_len),
+93 => wire__crate__api__backup__encrypted_dana_backup_encode_impl(ptr, rust_vec_len, data_len),
+94 => wire__crate__api__backup__encrypted_dana_backup_new_impl(ptr, rust_vec_len, data_len),
+95 => wire__crate__api__structs__fiat_currency_display_name_impl(ptr, rust_vec_len, data_len),
+96 => wire__crate__api__structs__fiat_currency_minor_units_impl(ptr, rust_vec_len, data_len),
+97 => wire__crate__api__structs__fiat_currency_symbol_impl(ptr, rust_vec_len, data_len),
+100 => wire__crate__api__backup__settings_backup_new_impl(ptr, rust_vec_len, data_len),
+101 => wire__crate__api__validate__validate_address_with_network_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -5526,6 +5599,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::structs::ApiRecordedTransacti
             crate::api::structs::ApiRecordedTransaction::Outgoing(field0) => {
                 [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            crate::api::structs::ApiRecordedTransaction::UnknownOutgoing(field0) => {
+                [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -5587,6 +5663,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::ApiRecordedTransacti
     for crate::api::structs::ApiRecordedTransactionOutgoing
 {
     fn into_into_dart(self) -> crate::api::structs::ApiRecordedTransactionOutgoing {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::structs::ApiRecordedTransactionUnknownOutgoing {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.amount.into_into_dart().into_dart(),
+            self.confirmed_at.into_into_dart().into_dart(),
+            self.spent_outpoints.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::structs::ApiRecordedTransactionUnknownOutgoing
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::structs::ApiRecordedTransactionUnknownOutgoing>
+    for crate::api::structs::ApiRecordedTransactionUnknownOutgoing
+{
+    fn into_into_dart(self) -> crate::api::structs::ApiRecordedTransactionUnknownOutgoing {
         self
     }
 }
@@ -6091,6 +6189,12 @@ impl SseEncode for crate::api::structs::ApiRecordedTransaction {
                     field0, serializer,
                 );
             }
+            crate::api::structs::ApiRecordedTransaction::UnknownOutgoing(field0) => {
+                <i32>::sse_encode(2, serializer);
+                <crate::api::structs::ApiRecordedTransactionUnknownOutgoing>::sse_encode(
+                    field0, serializer,
+                );
+            }
             _ => {
                 unimplemented!("");
             }
@@ -6116,6 +6220,15 @@ impl SseEncode for crate::api::structs::ApiRecordedTransactionOutgoing {
         <Option<u32>>::sse_encode(self.confirmed_at, serializer);
         <crate::api::structs::ApiAmount>::sse_encode(self.change, serializer);
         <crate::api::structs::ApiAmount>::sse_encode(self.fee, serializer);
+    }
+}
+
+impl SseEncode for crate::api::structs::ApiRecordedTransactionUnknownOutgoing {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::structs::ApiAmount>::sse_encode(self.amount, serializer);
+        <u32>::sse_encode(self.confirmed_at, serializer);
+        <Vec<String>>::sse_encode(self.spent_outpoints, serializer);
     }
 }
 

--- a/rust/src/state/constants.rs
+++ b/rust/src/state/constants.rs
@@ -8,6 +8,7 @@ use spdk::{
 pub enum RecordedTransaction {
     Incoming(RecordedTransactionIncoming),
     Outgoing(RecordedTransactionOutgoing),
+    UnknownOutgoing(RecordedTransactionUnknownOutgoing),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -26,4 +27,11 @@ pub struct RecordedTransactionOutgoing {
     pub change: Amount,
     #[serde(default)]
     pub fee: Amount,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RecordedTransactionUnknownOutgoing {
+    pub spent_outpoints: Vec<OutPoint>,
+    pub amount: Amount,
+    pub confirmed_at: Height,
 }


### PR DESCRIPTION
This is important in cases where users have their seed phrases imported in 2 different wallets. If both wallets are at height N and wallet A spends an output, then wallet B will not know this output is spent and will not look into checking if it's confirmed.

This commits changes this behavior to also check unspent outputs for confirmation.