### PR TITLE
Disable pin screen for the moment

### DIFF
--- a/lib/widgets/pin_guard.dart
+++ b/lib/widgets/pin_guard.dart
@@ -16,9 +16,10 @@ class PinGuard extends StatefulWidget {
 }
 
 class _PinGuardState extends State<PinGuard> {
-  bool _isPinSet = false;
-  bool _isLoading = true;
-  bool _isPinVerified = false;
+  // We disable the PIN screen (for now), so we set to automatically verified
+  bool _isPinSet = true;
+  bool _isLoading = false;
+  bool _isPinVerified = true;
 
   @override
   void initState() {


### PR DESCRIPTION
We'll re-enable the pin screen once we've ironed out the UX for it (forgetting PIN-code flow, biometric authentication flow)