### PR TITLE
Remove storing default settings

### DIFF
--- a/lib/data/enums/network.dart
+++ b/lib/data/enums/network.dart
@@ -24,7 +24,7 @@ enum Network {
     }
   }
 
-  String getDefaultBlindbitUrl() {
+  String get defaultBlindbitUrl {
     switch (this) {
       case Network.mainnet:
         if (isDevEnv && const String.fromEnvironment("MAINNET_URL") != "") {

--- a/lib/generated/rust/api/backup.dart
+++ b/lib/generated/rust/api/backup.dart
@@ -124,16 +124,15 @@ class EncryptedDanaBackup {
 }
 
 class SettingsBackup {
-  final String blindbitUrl;
-  final int dustLimit;
+  final String? blindbitUrl;
+  final int? dustLimit;
 
   const SettingsBackup.raw({
-    required this.blindbitUrl,
-    required this.dustLimit,
+    this.blindbitUrl,
+    this.dustLimit,
   });
 
-  factory SettingsBackup(
-          {required String blindbitUrl, required int dustLimit}) =>
+  factory SettingsBackup({String? blindbitUrl, int? dustLimit}) =>
       RustLib.instance.api.crateApiBackupSettingsBackupNew(
           blindbitUrl: blindbitUrl, dustLimit: dustLimit);
 

--- a/lib/generated/rust/frb_generated.dart
+++ b/lib/generated/rust/frb_generated.dart
@@ -387,7 +387,7 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSimpleInitApp();
 
   SettingsBackup crateApiBackupSettingsBackupNew(
-      {required String blindbitUrl, required int dustLimit});
+      {String? blindbitUrl, int? dustLimit});
 
   void crateApiValidateValidateAddressWithNetwork(
       {required String address, required String network});
@@ -3182,12 +3182,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   SettingsBackup crateApiBackupSettingsBackupNew(
-      {required String blindbitUrl, required int dustLimit}) {
+      {String? blindbitUrl, int? dustLimit}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_String(blindbitUrl, serializer);
-        sse_encode_u_32(dustLimit, serializer);
+        sse_encode_opt_String(blindbitUrl, serializer);
+        sse_encode_opt_box_autoadd_u_32(dustLimit, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
       },
       codec: SseCodec(
@@ -3984,8 +3984,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 2)
       throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
     return SettingsBackup.raw(
-      blindbitUrl: dco_decode_String(arr[0]),
-      dustLimit: dco_decode_u_32(arr[1]),
+      blindbitUrl: dco_decode_opt_String(arr[0]),
+      dustLimit: dco_decode_opt_box_autoadd_u_32(arr[1]),
     );
   }
 
@@ -4802,8 +4802,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   SettingsBackup sse_decode_settings_backup(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_blindbitUrl = sse_decode_String(deserializer);
-    var var_dustLimit = sse_decode_u_32(deserializer);
+    var var_blindbitUrl = sse_decode_opt_String(deserializer);
+    var var_dustLimit = sse_decode_opt_box_autoadd_u_32(deserializer);
     return SettingsBackup.raw(
         blindbitUrl: var_blindbitUrl, dustLimit: var_dustLimit);
   }
@@ -5589,8 +5589,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_settings_backup(
       SettingsBackup self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.blindbitUrl, serializer);
-    sse_encode_u_32(self.dustLimit, serializer);
+    sse_encode_opt_String(self.blindbitUrl, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.dustLimit, serializer);
   }
 
   @protected

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,11 +47,12 @@ void main() async {
 
   if (walletLoaded) {
     final network = walletState.network;
-    final blindbitUrl = await SettingsRepository.instance.getBlindbitUrl();
+    final blindbitUrl = await SettingsRepository.instance.getBlindbitUrl() ??
+        network.defaultBlindbitUrl;
 
     chainState.initialize(network);
 
-    final connected = await chainState.connect(blindbitUrl!);
+    final connected = await chainState.connect(blindbitUrl);
     if (!connected) {
       Logger().w("Failed to connect");
       // Continue without chain sync - wallet still usable for local operations

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -47,12 +47,13 @@ void main() async {
 
   if (walletLoaded) {
     final network = walletState.network;
-    final blindbitUrl = await SettingsRepository.instance.getBlindbitUrl();
+    final blindbitUrl = await SettingsRepository.instance.getBlindbitUrl() ??
+        network.defaultBlindbitUrl;
 
     chainState.initialize(network);
 
     // Continue without chain sync - wallet still usable for local operations
-    final connected = await chainState.connect(blindbitUrl!);
+    final connected = await chainState.connect(blindbitUrl);
     if (!connected) {
       Logger().w("Failed to connect");
     }

--- a/lib/screens/onboarding/overview.dart
+++ b/lib/screens/onboarding/overview.dart
@@ -4,11 +4,9 @@ import 'package:danawallet/data/enums/network.dart';
 import 'package:danawallet/exceptions.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
-import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/screens/onboarding/choose_network.dart';
 import 'package:danawallet/screens/onboarding/onboarding_skeleton.dart';
 import 'package:danawallet/screens/onboarding/recovery/seed_phrase.dart';
-import 'package:danawallet/screens/pin/pin_setup_screen.dart';
 import 'package:danawallet/services/backup_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/scan_progress_notifier.dart';
@@ -55,11 +53,12 @@ class _OverviewScreenState extends State<OverviewScreen> {
           await walletState.initialize();
           final network = walletState.network;
           final blindbitUrl =
-              await SettingsRepository.instance.getBlindbitUrl();
+              await SettingsRepository.instance.getBlindbitUrl() ??
+                  network.defaultBlindbitUrl;
           chainState.initialize(network);
 
           // we can safely ignore the result of connecting, since we get the birthday from the backup
-          await chainState.connect(blindbitUrl!);
+          await chainState.connect(blindbitUrl);
 
           chainState.startSyncService(walletState, scanProgress, true);
           if (context.mounted) {
@@ -99,8 +98,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
     final scanProgress =
         Provider.of<ScanProgressNotifier>(context, listen: false);
 
-    await SettingsRepository.instance.defaultSettings(network);
-    final blindbitUrl = network.getDefaultBlindbitUrl();
+    final blindbitUrl = network.defaultBlindbitUrl;
 
     chainState.initialize(network);
     final connected = await chainState.connect(blindbitUrl);

--- a/lib/screens/onboarding/recovery/seed_phrase.dart
+++ b/lib/screens/onboarding/recovery/seed_phrase.dart
@@ -3,9 +3,6 @@ import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/enums/network.dart';
 import 'package:danawallet/data/enums/warning_type.dart';
 import 'package:danawallet/global_functions.dart';
-import 'package:danawallet/repositories/settings_repository.dart';
-import 'package:danawallet/screens/home/home.dart';
-import 'package:danawallet/screens/pin/pin_setup_screen.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/scan_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
@@ -48,8 +45,7 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
       final scanProgress =
           Provider.of<ScanProgressNotifier>(context, listen: false);
 
-      await SettingsRepository.instance.defaultSettings(widget.network);
-      final blindbitUrl = widget.network.getDefaultBlindbitUrl();
+      final blindbitUrl = widget.network.defaultBlindbitUrl;
 
       await walletState.restoreWallet(widget.network, mnemonic);
 

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -71,7 +71,7 @@ class SettingsScreen extends StatelessWidget {
 
     String? url;
     if (value is bool && value) {
-      url = network.getDefaultBlindbitUrl();
+      url = network.defaultBlindbitUrl;
     } else if (value is String) {
       url = value;
     }
@@ -167,7 +167,9 @@ class SettingsScreen extends StatelessWidget {
     final homeState = Provider.of<HomeState>(context, listen: false);
     final fiatExchangeRate =
         Provider.of<FiatExchangeRateState>(context, listen: false);
-    final currentCurrency = await SettingsRepository.instance.getFiatCurrency();
+    final currentCurrency =
+        (await SettingsRepository.instance.getFiatCurrency()) ??
+            defaultCurrency;
     if (context.mounted) {
       goToScreen(
           context,

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -16,7 +16,8 @@ class FiatExchangeRateState extends ChangeNotifier {
 
   static Future<FiatExchangeRateState> create() async {
     final instance = FiatExchangeRateState._();
-    final currency = await SettingsRepository.instance.getFiatCurrency();
+    final currency =
+        await SettingsRepository.instance.getFiatCurrency() ?? defaultCurrency;
     instance.currency = currency;
 
     try {

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/stream.dart';
 import 'package:danawallet/generated/rust/api/wallet.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
@@ -63,8 +64,9 @@ class ScanProgressNotifier extends ChangeNotifier {
     try {
       final wallet = await walletState.getWalletFromSecureStorage();
       final settings = SettingsRepository.instance;
-      final blindbitUrl = await settings.getBlindbitUrl();
-      final dustLimit = await settings.getDustLimit();
+      final blindbitUrl = await settings.getBlindbitUrl() ??
+          walletState.network.defaultBlindbitUrl;
+      final dustLimit = await settings.getDustLimit() ?? defaultDustLimit;
 
       final lastScan = walletState.lastScan;
 
@@ -73,8 +75,8 @@ class ScanProgressNotifier extends ChangeNotifier {
 
       activate(walletState.lastScan);
       await wallet.scanToTip(
-          blindbitUrl: blindbitUrl!,
-          dustLimit: BigInt.from(dustLimit!),
+          blindbitUrl: blindbitUrl,
+          dustLimit: BigInt.from(dustLimit),
           ownedOutpoints: ownedOutPoints,
           lastScan: lastScan);
     } catch (e) {

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -241,9 +241,11 @@ class WalletState extends ChangeNotifier {
       if (unsignedTx.network == Network.regtest.toCoreArg) {
         // if we are currently on regtest, it's not possible to use our normal broadcasting flow
         // instead, we will forward the transaction to blindbit
-        final blindbitUrl = await SettingsRepository.instance.getBlindbitUrl();
+        final blindbitUrl =
+            await SettingsRepository.instance.getBlindbitUrl() ??
+                Network.regtest.defaultBlindbitUrl;
         txid = await SpWallet.broadcastUsingBlindbit(
-            blindbitUrl: blindbitUrl!, tx: signedTx);
+            blindbitUrl: blindbitUrl, tx: signedTx);
       } else {
         txid = await SpWallet.broadcastTx(
             tx: signedTx, network: network.toCoreArg);

--- a/rust/src/api/backup.rs
+++ b/rust/src/api/backup.rs
@@ -68,7 +68,7 @@ impl EncryptedDanaBackup {
             }
         }
 
-        Ok(DanaBackup::decode(String::from_utf8(final_result)?)?)
+        DanaBackup::decode(String::from_utf8(final_result)?)
     }
 
     #[frb(sync)]
@@ -199,13 +199,13 @@ impl WalletBackup {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SettingsBackup {
-    pub blindbit_url: String,
-    pub dust_limit: u32,
+    pub blindbit_url: Option<String>,
+    pub dust_limit: Option<u32>,
 }
 
 impl SettingsBackup {
     #[frb(sync)]
-    pub fn new(blindbit_url: String, dust_limit: u32) -> Self {
+    pub fn new(blindbit_url: Option<String>, dust_limit: Option<u32>) -> Self {
         Self {
             blindbit_url,
             dust_limit,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -4344,8 +4344,8 @@ fn wire__crate__api__backup__settings_backup_new_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_blindbit_url = <String>::sse_decode(&mut deserializer);
-            let api_dust_limit = <u32>::sse_decode(&mut deserializer);
+            let api_blindbit_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_dust_limit = <Option<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(crate::api::backup::SettingsBackup::new(
@@ -5045,8 +5045,8 @@ impl SseDecode for crate::stream::ScanProgress {
 impl SseDecode for crate::api::backup::SettingsBackup {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_blindbitUrl = <String>::sse_decode(deserializer);
-        let mut var_dustLimit = <u32>::sse_decode(deserializer);
+        let mut var_blindbitUrl = <Option<String>>::sse_decode(deserializer);
+        let mut var_dustLimit = <Option<u32>>::sse_decode(deserializer);
         return crate::api::backup::SettingsBackup {
             blindbit_url: var_blindbitUrl,
             dust_limit: var_dustLimit,
@@ -6329,8 +6329,8 @@ impl SseEncode for crate::stream::ScanProgress {
 impl SseEncode for crate::api::backup::SettingsBackup {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.blindbit_url, serializer);
-        <u32>::sse_encode(self.dust_limit, serializer);
+        <Option<String>>::sse_encode(self.blindbit_url, serializer);
+        <Option<u32>>::sse_encode(self.dust_limit, serializer);
     }
 }
 


### PR DESCRIPTION
Allow blindbit_url, dust_limit and fiat_currency to be null, instead of setting a default when creating a wallet.

This is important for cases where we want to change the defaults. For example, if we set a different dust value, this change won't be adopted by wallets since the previous dust value will be set on wallet creation.

This change is useful for #240