### PR TITLE
Don't write default value to setting storage when resetting

### DIFF
--- a/lib/repositories/settings_repository.dart
+++ b/lib/repositories/settings_repository.dart
@@ -20,24 +20,36 @@ class SettingsRepository {
         .clear(allowList: {_keyBlindbitUrl, _keyDustLimit, _keyFiatCurrency});
   }
 
-  Future<void> setBlindbitUrl(String url) async {
-    return await prefs.setString(_keyBlindbitUrl, url);
+  Future<void> setBlindbitUrl(String? url) async {
+    if (url != null) {
+      return await prefs.setString(_keyBlindbitUrl, url);
+    } else {
+      return await prefs.remove(_keyBlindbitUrl);
+    }
   }
 
   Future<String?> getBlindbitUrl() async {
     return await prefs.getString(_keyBlindbitUrl);
   }
 
-  Future<void> setDustLimit(int value) async {
-    return await prefs.setInt(_keyDustLimit, value);
+  Future<void> setDustLimit(int? value) async {
+    if (value != null) {
+      return await prefs.setInt(_keyDustLimit, value);
+    } else {
+      return await prefs.remove(_keyDustLimit);
+    }
   }
 
   Future<int?> getDustLimit() async {
     return await prefs.getInt(_keyDustLimit);
   }
 
-  Future<void> setFiatCurrency(FiatCurrency currency) async {
-    return await prefs.setString(_keyFiatCurrency, currency.name);
+  Future<void> setFiatCurrency(FiatCurrency? currency) async {
+    if (currency != null) {
+      return await prefs.setString(_keyFiatCurrency, currency.name);
+    } else {
+      return await prefs.remove(_keyFiatCurrency);
+    }
   }
 
   Future<FiatCurrency?> getFiatCurrency() async {

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -58,7 +58,6 @@ class SettingsScreen extends StatelessWidget {
   }
 
   Future<void> _setBlindbitUrl(BuildContext context) async {
-    final wallet = Provider.of<WalletState>(context, listen: false);
     SettingsRepository settings = SettingsRepository.instance;
     final chainState = Provider.of<ChainState>(context, listen: false);
     final controller = TextEditingController();
@@ -67,26 +66,19 @@ class SettingsScreen extends StatelessWidget {
     final value = await showInputAlertDialog(controller, TextInputType.url,
         'Set blindbit url', 'Only blindbit is currently supported');
 
-    final network = wallet.network;
-
-    String? url;
-    if (value is bool && value) {
-      url = network.defaultBlindbitUrl;
-    } else if (value is String) {
-      url = value;
-    }
-
-    if (url != null) {
+    if (value is String) {
       try {
-        final success = await chainState.updateBlindbitUrl(url);
+        final success = await chainState.updateBlindbitUrl(value);
         if (success) {
-          await settings.setBlindbitUrl(url);
+          await settings.setBlindbitUrl(value);
         } else {
           displayNotification("Wrong network for blindbit server");
         }
       } catch (e) {
         displayError(e);
       }
+    } else if (value is bool && value) {
+      await settings.setBlindbitUrl(null);
     }
   }
 
@@ -106,7 +98,7 @@ class SettingsScreen extends StatelessWidget {
     if (value is int) {
       await settings.setDustLimit(value);
     } else if (value is bool && value) {
-      await settings.setDustLimit(defaultDustLimit);
+      await settings.setDustLimit(null);
     }
   }
 


### PR DESCRIPTION
When choosing the default value for dust_limit/blindbit_url, drop the stored setting instead of writing the default value to disk.