### PR TITLE
Make dana address scrolling on ready_to_send screen

### DIFF
--- a/lib/screens/home/wallet/spend/ready_to_send.dart
+++ b/lib/screens/home/wallet/spend/ready_to_send.dart
@@ -5,9 +5,9 @@ import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
 import 'package:danawallet/screens/home/wallet/spend/transaction_sent.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
-import 'package:danawallet/widgets/buttons/footer/footer_button_outlined.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:text_scroll/text_scroll.dart';
 
 class ReadyToSendScreen extends StatefulWidget {
   const ReadyToSendScreen({super.key});
@@ -76,61 +76,13 @@ class ReadyToSendScreenState extends State<ReadyToSendScreen> {
             const SizedBox(
               height: 50.0,
             ),
-            Row(
-              children: [
-                Text(
-                  'To',
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral7),
-                ),
-                const Spacer(),
-                Text(
-                  displayRecipient,
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral8),
-                )
-              ],
-            ),
+            entryRow('To', displayRecipient, true),
             const Divider(),
-            Row(
-              children: [
-                Text(
-                  'Amount',
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral7),
-                ),
-                const Spacer(),
-                Text(
-                  displayAmount,
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral8),
-                )
-              ],
-            ),
+            entryRow('Amount', displayAmount, false),
             const Divider(),
-            Row(
-              children: [
-                Text(
-                  'Arrival time',
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral7),
-                ),
-                const Spacer(),
-                Text(
-                  displayArrivalTime,
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral8),
-                )
-              ],
-            ),
+            entryRow('Arrival time', displayArrivalTime, false),
             const Divider(),
-            Row(
-              children: [
-                Text(
-                  'Fee',
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral7),
-                ),
-                const Spacer(),
-                Text(
-                  displayEstimatedFee,
-                  style: BitcoinTextStyle.title5(Bitcoin.neutral8),
-                )
-              ],
-            ),
+            entryRow('Fee', displayEstimatedFee, false),
           ],
         ),
         footer: Column(
@@ -147,4 +99,30 @@ class ReadyToSendScreenState extends State<ReadyToSendScreen> {
           ],
         ));
   }
+}
+
+Widget entryRow(String left, String right, bool scrolling) {
+  return Row(
+    children: [
+      Text(
+        left,
+        style: BitcoinTextStyle.title5(Bitcoin.neutral7),
+      ),
+      const SizedBox(width: 30),
+      if (scrolling)
+        Expanded(
+            child: TextScroll(right,
+                mode: TextScrollMode.bouncing,
+                delayBefore: const Duration(milliseconds: 1500),
+                pauseOnBounce: const Duration(milliseconds: 1000),
+                pauseBetween: const Duration(milliseconds: 1000),
+                textAlign: TextAlign.end,
+                style: BitcoinTextStyle.title5(Bitcoin.neutral8))),
+      if (!scrolling)
+        Expanded(
+            child: Text(right,
+                textAlign: TextAlign.end,
+                style: BitcoinTextStyle.title5(Bitcoin.neutral8))),
+    ],
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -967,6 +967,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  text_scroll:
+    dependency: "direct main"
+    description:
+      name: text_scroll
+      sha256: "164b49e6134fca874989213d4e7ba225e2c3f9e30d9e32f14d543b2fc55716a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   url_launcher: ^6.3.1
   share_plus: ^11.0.0
   auto_size_text: ^3.0.0
+  text_scroll: ^0.2.1
 
 # temporary fix, see: https://github.com/juliansteenbakker/flutter_secure_storage/issues/920
 dependency_overrides:


### PR DESCRIPTION
If there is not enough screen space to draw the entire dana address, make the text scrollable.

I don't like how this TextScroll widget seems to not work well with resizing of screens so i don't think we should rely on it too much, but for now it does the job.