### PR TITLE
Use different name servers for different dev networks

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -38,7 +38,9 @@ const int bitcoinUnits = 100000000;
 // String that displays when amount is hidden
 const String hideAmountFormat = "*****";
 
-// the in-production name server, only used on live flavors
+// the in-production name server, only used on live flavors with mainnet
 const String nameServerLive = "https://nameserver.danawallet.app/v1";
-// name server for all other flavors (dev, signet)
-const String nameServerDev = "https://test.nameserver.danawallet.app/v1";
+// name server for other flavors that use mainnet
+const String nameServerDevMainnet = "https://main.dev.nameserver.danawallet.app/v1";
+// name server for other flavors that user testnet/signet
+const String nameServerDevTestnet = "https://test.dev.nameserver.danawallet.app/v1";

--- a/lib/data/models/name_server_info_response.dart
+++ b/lib/data/models/name_server_info_response.dart
@@ -1,16 +1,16 @@
 class NameServerInfoResponse {
   final String domain;
-  final bool mainnetOnly;
+  final String network;
 
   const NameServerInfoResponse({
     required this.domain,
-    required this.mainnetOnly,
+    required this.network,
   });
 
   factory NameServerInfoResponse.fromJson(Map<String, dynamic> json) {
     return NameServerInfoResponse(
       domain: json['domain'] as String,
-      mainnetOnly: json['mainnet_only'] as bool,
+      network: json['network'] as String,
     );
   }
 }

--- a/lib/repositories/name_server_repository.dart
+++ b/lib/repositories/name_server_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:danawallet/constants.dart';
+import 'package:danawallet/data/enums/network.dart';
 import 'package:danawallet/data/models/name_server_info_response.dart';
 import 'package:danawallet/data/models/name_server_lookup_response.dart';
 import 'package:danawallet/data/models/name_server_register_request.dart';
@@ -9,10 +10,24 @@ import 'package:http/http.dart' as http;
 import 'package:logger/logger.dart';
 
 class NameServerRepository {
-  NameServerRepository();
+  String baseUrl;
 
-  // only live flavor should use the real domain, others use the test domain
-  String get baseUrl => (appFlavor == 'live') ? nameServerLive : nameServerDev;
+  NameServerRepository({required Network network})
+      : baseUrl = (() {
+          // live flavors only allow mainnet, so we don't need to separate based on the network
+          if (appFlavor == 'live') {
+            return nameServerLive;
+          } else {
+            // non-live flavors can have different networks
+            if (network == Network.mainnet) {
+              // used for mainnet
+              return nameServerDevMainnet;
+            } else {
+              // used for testnet/signet
+              return nameServerDevTestnet;
+            }
+          }
+        })();
 
   Future<NameServerInfoResponse> getInfo() async {
     Logger().d("Getting name server info");

--- a/lib/screens/onboarding/dana_address_setup.dart
+++ b/lib/screens/onboarding/dana_address_setup.dart
@@ -68,6 +68,7 @@ class _DanaAddressSetupScreenState extends State<DanaAddressSetupScreen> {
   bool _hasUserEdited = false;
   String? _suggestedUsername;
   String? _domain;
+  DanaAddressService? _danaAddressService;
 
   @override
   void initState() {
@@ -82,13 +83,15 @@ class _DanaAddressSetupScreenState extends State<DanaAddressSetupScreen> {
 
   Future<void> loadUsernameAndDomain() async {
     final walletState = Provider.of<WalletState>(context, listen: false);
+    final addressService = DanaAddressService(network: walletState.network);
 
     while (true) {
       try {
         final suggestedUsername = await walletState.createSuggestedUsername();
-        final domain = await DanaAddressService().danaAddressDomain;
+        final domain = await addressService.danaAddressDomain;
 
         setState(() {
+          _danaAddressService = addressService;
           _suggestedUsername = suggestedUsername;
           _domain = domain;
         });
@@ -251,10 +254,8 @@ class _DanaAddressSetupScreenState extends State<DanaAddressSetupScreen> {
     });
 
     try {
-      final walletState = Provider.of<WalletState>(context, listen: false);
-
-      final isAvailable = await DanaAddressService()
-          .isDanaUsernameAvailable(username, walletState.network);
+      final isAvailable =
+          await _danaAddressService!.isDanaUsernameAvailable(username);
       if (mounted && _customUsername == username) {
         setState(() {
           _isCustomUsernameAvailable = isAvailable;

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -294,10 +294,10 @@ class WalletState extends ChangeNotifier {
 
   Future<String?> createSuggestedUsername() async {
     // Generate an available dana address (without registering yet)
-    return await DanaAddressService().generateAvailableDanaAddress(
+    return await DanaAddressService(network: network)
+        .generateAvailableDanaAddress(
       spAddress: receiveAddress,
       maxRetries: 5,
-      network: network,
     );
   }
 
@@ -307,8 +307,8 @@ class WalletState extends ChangeNotifier {
     }
 
     Logger().i('Registering dana address with username: $username');
-    final registeredAddress = await DanaAddressService().registerUser(
-        username: username, spAddress: receiveAddress, network: network);
+    final registeredAddress = await DanaAddressService(network: network)
+        .registerUser(username: username, spAddress: receiveAddress);
 
     // Registration successful
     Logger().i('Registration successful: $registeredAddress');
@@ -360,8 +360,8 @@ class WalletState extends ChangeNotifier {
     // but first, we check if the name server already has an address for us
     Logger().i("Attempting to look up dana address");
     try {
-      final lookupResult =
-          await DanaAddressService().lookupDanaAddress(receiveAddress, network);
+      final lookupResult = await DanaAddressService(network: network)
+          .lookupDanaAddress(receiveAddress);
       if (lookupResult != null) {
         Logger().i("Found dana address: $lookupResult");
         danaAddress = lookupResult;


### PR DESCRIPTION
We now use 3 name servers:
- production name server for the live flavor, this only accepts 'mainnet' addresses
- dev name server for mainnet. This is for non-live flavors that use Mainnet, e.g. Dev flavor with Mainnet selected
- dev name server for testnet. This is for non-live flavors that use Testnet/Signet, e.g. the 'Signet' flavor or Dev flavor with these networks selected.

Based on https://github.com/Sosthene00/dana-nameserver/pull/12