### PR TITLE
Allow delayed setting of the 'you'-contact bip353Address

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,12 +76,16 @@ void main() async {
 
     chainState.startSyncService(walletState, scanNotifier, true);
 
-    if (await walletState.checkDanaAddressRegistrationNeeded()) {
+    final addressRegistrationNeeded =
+        await walletState.checkDanaAddressRegistrationNeeded();
+
+    // initialize contacts with the 'you' contact
+    contactsState.initialize(
+        walletState.receivePaymentCode, walletState.danaAddress);
+
+    if (addressRegistrationNeeded) {
       landingPage = const DanaAddressSetupScreen();
     } else {
-      // initialize contacts state with our receive & dana address, so that we can create the self contact
-      contactsState.initialize(
-          walletState.receivePaymentCode, walletState.danaAddress);
       landingPage = const PinGuard();
     }
   } else {

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -78,12 +78,16 @@ void main() async {
 
     chainState.startSyncService(walletState, scanNotifier, true);
 
-    if (await walletState.checkDanaAddressRegistrationNeeded()) {
+    final addressRegistrationNeeded =
+        await walletState.checkDanaAddressRegistrationNeeded();
+
+    // initialize contacts with the 'you' contact
+    contactsState.initialize(
+        walletState.receivePaymentCode, walletState.danaAddress);
+
+    if (addressRegistrationNeeded) {
       landingPage = const DanaAddressSetupScreen();
     } else {
-      // initialize contacts state with our receive & dana address, so that we can create the self contact
-      contactsState.initialize(
-          walletState.receivePaymentCode, walletState.danaAddress);
       landingPage = const PinGuard();
     }
   } else {

--- a/lib/screens/onboarding/dana_address_setup.dart
+++ b/lib/screens/onboarding/dana_address_setup.dart
@@ -319,8 +319,8 @@ class _DanaAddressSetupScreenState extends State<DanaAddressSetupScreen> {
         // Persist the dana address to storage (already done by registerDanaAddress, but ensure consistency)
         await WalletRepository.instance.saveDanaAddress(registeredAddress);
 
-        // Create a contact for the 'you' user
-        contactsState.initialize(walletState.receivePaymentCode, registeredAddress);
+        // Set the dana address for the 'you' user
+        contactsState.setYouContactDanaAddress(registeredAddress);
 
         if (context.mounted) {
           Navigator.pushAndRemoveUntil(

--- a/lib/screens/onboarding/overview.dart
+++ b/lib/screens/onboarding/overview.dart
@@ -109,6 +109,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
 
     final walletState = Provider.of<WalletState>(context, listen: false);
     final chainState = Provider.of<ChainState>(context, listen: false);
+    final contactsState = Provider.of<ContactsState>(context, listen: false);
     final scanProgress =
         Provider.of<ScanProgressNotifier>(context, listen: false);
 
@@ -123,6 +124,8 @@ class _OverviewScreenState extends State<OverviewScreen> {
       final chainTip = chainState.tip;
       await walletState.createNewWallet(network, chainTip);
 
+      // initialize contacts state with the user's payment code
+      contactsState.initialize(walletState.receivePaymentCode, null);
       if (network == Network.regtest && context.mounted) {
         // for regtest we bypass the dana address setup screen
         Navigator.pushAndRemoveUntil(
@@ -130,7 +133,6 @@ class _OverviewScreenState extends State<OverviewScreen> {
             MaterialPageRoute(builder: (context) => const PinGuard()),
             (Route<dynamic> route) => false);
       } else {
-        // Generate an available dana address (without registering yet)
         if (context.mounted) {
           Navigator.pushAndRemoveUntil(
               context,

--- a/lib/states/contacts_state.dart
+++ b/lib/states/contacts_state.dart
@@ -41,6 +41,22 @@ class ContactsState extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setYouContactDanaAddress(Bip353Address? danaAddress) async {
+    if (_youContact!.bip353Address != null) {
+      throw Exception("you-contact bip353Address already set");
+    }
+
+    // overwrite the you-contact
+    _youContact = Contact(
+      id: _youContact!.id,
+      name: _youContact!.name,
+      paymentCode: _youContact!.paymentCode,
+      bip353Address: danaAddress,
+    );
+
+    notifyListeners();
+  }
+
   /// Adds a new contact by dana address
   /// Resolves the dana address to SP address via DNS before saving
   ///

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -235,7 +235,8 @@ class WalletState extends ChangeNotifier {
 
     final feeAmount = unsignedTx.getFeeAmount();
 
-    final recipients = unsignedTx.getRecipients(changeAddress: changePaymentCode);
+    final recipients =
+        unsignedTx.getRecipients(changeAddress: changePaymentCode);
 
     final finalizedTx =
         SpWallet.finalizeTransaction(unsignedTransaction: unsignedTx);
@@ -344,7 +345,7 @@ class WalletState extends ChangeNotifier {
           return false;
         } else {
           Logger()
-              .w("Dana address is not pointing to out sp address, removing");
+              .w("Dana address is not pointing to our sp address, removing");
           danaAddress = null;
           // note: because we haven't found a valid address in memory, we don't return here
         }


### PR DESCRIPTION
By allowing a delayed setting, we don't need to initialize the contacts state at the same moment we have our Dana address. This means we can initialize the contact state at the same location that we initialize the wallet and chain states.