### PR TITLE
feat: Use signet as default for all flavors apart from live

### DIFF
--- a/lib/data/enums/network.dart
+++ b/lib/data/enums/network.dart
@@ -3,6 +3,7 @@ import 'package:danawallet/constants.dart';
 import 'package:danawallet/exceptions.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:flutter/services.dart';
+import 'package:logger/logger.dart';
 
 enum Network {
   mainnet,
@@ -109,16 +110,17 @@ enum Network {
 
   static Network get getNetworkForFlavor {
     switch (appFlavor) {
+      // only live flavor uses mainnet
       case 'live':
         return Network.mainnet;
+      // all other flavors use signet by default
       case 'signet':
-        return Network.signet;
-      // dev and local flavors default to regtest
       case 'dev':
       case 'local':
-        return Network.regtest;
+        return Network.signet;
       default:
-        throw UnknownFlavorException();
+        Logger().w("Unknown Flavor; defaulting to signet");
+        return Network.signet;
     }
   }
 }

--- a/lib/exceptions.dart
+++ b/lib/exceptions.dart
@@ -3,5 +3,3 @@ class InvalidAddressException implements Exception {}
 class InvalidNetworkException implements Exception {}
 
 class UninitializedExchangeRateException implements Exception {}
-
-class UnknownFlavorException implements Exception {}


### PR DESCRIPTION
- Dev flavor now defaults to signet instead of regtest
- Local flavor now default to signet instead of regtest
- Unknown flavors no longer throw an exception. Instead we print a warning and use signet