### PR TITLE
style: Use generic skeleton widget across different screen domains

### DIFF
--- a/lib/screens/home/wallet/spend/amount_selection.dart
+++ b/lib/screens/home/wallet/spend/amount_selection.dart
@@ -4,7 +4,7 @@ import 'package:danawallet/data/models/recipient_form.dart';
 import 'package:danawallet/generated/rust/api/structs.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/home/wallet/spend/fee_selection.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
@@ -84,7 +84,7 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
           displayAddress(context, recipientName, recipientTextStyle, 0.86);
     }
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
       showBackButton: true,
       title: 'Enter amount',
       body: Column(

--- a/lib/screens/home/wallet/spend/choose_recipient.dart
+++ b/lib/screens/home/wallet/spend/choose_recipient.dart
@@ -6,7 +6,7 @@ import 'package:danawallet/exceptions.dart';
 import 'package:danawallet/generated/rust/api/validate.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/home/wallet/spend/amount_selection.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/services/bip353_resolver.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
@@ -144,7 +144,7 @@ class ChooseRecipientScreenState extends State<ChooseRecipientScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return SpendSkeleton(
+    return ScreenSkeleton(
         showBackButton: true,
         title: 'Choose recipient(s)',
         body: Column(

--- a/lib/screens/home/wallet/spend/custom_fee_screen.dart
+++ b/lib/screens/home/wallet/spend/custom_fee_screen.dart
@@ -4,7 +4,7 @@ import 'package:danawallet/data/models/recipient_form_filled.dart';
 import 'package:danawallet/data/enums/selected_fee.dart';
 import 'package:danawallet/generated/rust/api/structs.dart';
 import 'package:danawallet/screens/home/wallet/spend/ready_to_send.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
@@ -110,7 +110,7 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
     final exchangeRate =
         Provider.of<FiatExchangeRateState>(context, listen: false);
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
       showBackButton: true,
       title: 'Custom Fee',
       body: Column(

--- a/lib/screens/home/wallet/spend/fee_selection.dart
+++ b/lib/screens/home/wallet/spend/fee_selection.dart
@@ -5,7 +5,7 @@ import 'package:danawallet/data/enums/selected_fee.dart';
 import 'package:danawallet/generated/rust/api/structs.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/home/wallet/spend/ready_to_send.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/screens/home/wallet/spend/custom_fee_screen.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
@@ -179,7 +179,7 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
     final exchangeRate =
         Provider.of<FiatExchangeRateState>(context, listen: false);
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
       showBackButton: true,
       title: 'Confirmation time',
       body: Column(children: [

--- a/lib/screens/home/wallet/spend/ready_to_send.dart
+++ b/lib/screens/home/wallet/spend/ready_to_send.dart
@@ -1,7 +1,7 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
 import 'package:danawallet/global_functions.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/screens/home/wallet/spend/transaction_sent.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
@@ -70,7 +70,7 @@ class ReadyToSendScreenState extends State<ReadyToSendScreen> {
 
     String displayEstimatedFee = form.unsignedTx!.getFeeAmount().displayBtc();
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
         showBackButton: true,
         title: 'Ready to send?',
         body: Column(

--- a/lib/screens/home/wallet/spend/transaction_sent.dart
+++ b/lib/screens/home/wallet/spend/transaction_sent.dart
@@ -3,7 +3,7 @@ import 'package:danawallet/data/enums/network.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
 import 'package:danawallet/generated/rust/api/validate.dart';
 import 'package:danawallet/screens/home/contacts/add_contact_sheet.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button_outlined.dart';
@@ -90,7 +90,7 @@ class _TransactionSentScreenState extends State<TransactionSentScreen> {
   Widget build(BuildContext context) {
     String estimatedTime = RecipientForm().selectedFee!.toEstimatedTime;
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
       showBackButton: false,
       body: Column(
           mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/screens/onboarding/choose_network.dart
+++ b/lib/screens/onboarding/choose_network.dart
@@ -1,6 +1,6 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/enums/network.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:flutter/material.dart';
 
@@ -52,7 +52,7 @@ class ChooseNetworkScreenState extends State<ChooseNetworkScreen> {
         title: "Confirm",
         onPressed: () => Navigator.of(context).pop(_selected));
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
         title: "Choose network",
         body: body,
         showBackButton: true,

--- a/lib/screens/settings/network/network_settings_screen.dart
+++ b/lib/screens/settings/network/network_settings_screen.dart
@@ -2,7 +2,7 @@ import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
-import 'package:danawallet/screens/settings/widgets/skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/home_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
@@ -108,28 +108,26 @@ class NetworkSettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final items = _buildItems(context);
 
-    return Scaffold(
-      body: SettingsSkeleton(
-        showBackButton: true,
-        title: 'Network settings',
-        body: ListView.separated(
-          itemCount: items.length,
-          separatorBuilder: (context, index) => Divider(
-            height: 1,
-            thickness: 1,
-            color: Bitcoin.neutral3,
-            indent: 56,
-          ),
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return SettingsListTile(
-              icon: item.icon,
-              title: item.title,
-              subtitle: item.subtitle,
-              onTap: item.onTap,
-            );
-          },
+    return ScreenSkeleton(
+      showBackButton: true,
+      title: 'Network settings',
+      body: ListView.separated(
+        itemCount: items.length,
+        separatorBuilder: (context, index) => Divider(
+          height: 1,
+          thickness: 1,
+          color: Bitcoin.neutral3,
+          indent: 56,
         ),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return SettingsListTile(
+            icon: item.icon,
+            title: item.title,
+            subtitle: item.subtitle,
+            onTap: item.onTap,
+          );
+        },
       ),
     );
   }

--- a/lib/screens/settings/personalization/change_fiat_screen.dart
+++ b/lib/screens/settings/personalization/change_fiat_screen.dart
@@ -1,6 +1,6 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/generated/rust/api/structs.dart';
-import 'package:danawallet/screens/home/wallet/spend/spend_skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:flutter/material.dart';
 
@@ -54,7 +54,7 @@ class ChangeFiatScreenState extends State<ChangeFiatScreen> {
     final footer = FooterButton(
         title: "Confirm", onPressed: () => widget.onConfirm(_selected!));
 
-    return SpendSkeleton(
+    return ScreenSkeleton(
         title: "Choose fiat currency",
         body: body,
         showBackButton: true,

--- a/lib/screens/settings/personalization/personalisation_settings_screen.dart
+++ b/lib/screens/settings/personalization/personalisation_settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/screens/settings/personalization/change_fiat_screen.dart';
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
-import 'package:danawallet/screens/settings/widgets/skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
 import 'package:flutter/material.dart';
@@ -51,28 +51,26 @@ class PersonalisationSettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final items = _buildItems(context);
 
-    return Scaffold(
-      body: SettingsSkeleton(
-        showBackButton: true,
-        title: 'Personalisation settings',
-        body: ListView.separated(
-          itemCount: items.length,
-          separatorBuilder: (context, index) => Divider(
-            height: 1,
-            thickness: 1,
-            color: Bitcoin.neutral3,
-            indent: 56,
-          ),
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return SettingsListTile(
-              icon: item.icon,
-              title: item.title,
-              subtitle: item.subtitle,
-              onTap: item.onTap,
-            );
-          },
+    return ScreenSkeleton(
+      showBackButton: true,
+      title: 'Personalisation settings',
+      body: ListView.separated(
+        itemCount: items.length,
+        separatorBuilder: (context, index) => Divider(
+          height: 1,
+          thickness: 1,
+          color: Bitcoin.neutral3,
+          indent: 56,
         ),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return SettingsListTile(
+            icon: item.icon,
+            title: item.title,
+            subtitle: item.subtitle,
+            onTap: item.onTap,
+          );
+        },
       ),
     );
   }

--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/screens/onboarding/introduction.dart';
 import 'package:danawallet/screens/recovery/view_mnemonic_screen.dart';
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
-import 'package:danawallet/screens/settings/widgets/skeleton.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/services/backup_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
@@ -119,29 +119,27 @@ class WalletSettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final items = _buildItems(context);
 
-    return Scaffold(
-      body: SettingsSkeleton(
-        showBackButton: true,
-        title: 'Wallet settings',
-        body: ListView.separated(
-          itemCount: items.length,
-          separatorBuilder: (context, index) => Divider(
-            height: 1,
-            thickness: 1,
-            color: Bitcoin.neutral3,
-            indent: 56,
-          ),
-          itemBuilder: (context, index) {
-            final item = items[index];
-            return SettingsListTile(
-              icon: item.icon,
-              title: item.title,
-              subtitle: item.subtitle,
-              onTap: item.onTap,
-              isDestructive: item.isDestructive,
-            );
-          },
+    return ScreenSkeleton(
+      showBackButton: true,
+      title: 'Wallet settings',
+      body: ListView.separated(
+        itemCount: items.length,
+        separatorBuilder: (context, index) => Divider(
+          height: 1,
+          thickness: 1,
+          color: Bitcoin.neutral3,
+          indent: 56,
         ),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return SettingsListTile(
+            icon: item.icon,
+            title: item.title,
+            subtitle: item.subtitle,
+            onTap: item.onTap,
+            isDestructive: item.isDestructive,
+          );
+        },
       ),
     );
   }

--- a/lib/widgets/skeletons/screen_skeleton.dart
+++ b/lib/widgets/skeletons/screen_skeleton.dart
@@ -2,12 +2,15 @@ import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/widgets/back_button.dart';
 import 'package:flutter/material.dart';
 
-class SpendSkeleton extends StatelessWidget {
+// This is the main screen template widget.
+// Generally, this template should be used across all full-sized screens,
+// in order to make things like padding and button placement consistent.
+class ScreenSkeleton extends StatelessWidget {
   final bool showBackButton;
   final String? title;
   final Widget body;
   final Widget? footer;
-  const SpendSkeleton(
+  const ScreenSkeleton(
       {super.key,
       this.title,
       required this.body,


### PR DESCRIPTION
We have multiple skeletons for different screen domains, e.g. settings screens and spend screens. As long as the screens have the same general layout (title, optional back button, main content in a body, optional footer), we should make them use the same skeleton widget.

Note: not everything needs to use the generic skeleton widget, for example, we may want to use a different screen layout during the onboarding flow. But for most screens, we want the layout to be consistent.