### PR TITLE
feat: make entire fee selection tile clickable

### DIFF
--- a/lib/screens/home/wallet/spend/fee_selection.dart
+++ b/lib/screens/home/wallet/spend/fee_selection.dart
@@ -146,6 +146,11 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
           leading: Radio<SelectedFee>(
             value: fee,
           ),
+          onTap: () {
+            setState(() {
+              _selected = fee;
+            });
+          },
         );
       case SelectedFee.custom:
         return ListTile(


### PR DESCRIPTION
Instead of having to click the radio widget on the left, make the entire tile clickable.