### PR TITLE
Fix bip353 display overflow

### DIFF
--- a/lib/global_functions.dart
+++ b/lib/global_functions.dart
@@ -372,6 +372,20 @@ Widget danaAddressAsRichText(String danaAddress, double? fontSize) {
   );
 }
 
+Text danaAddressAsSubtitle(String danaAddress,
+    {int maxChars = 32, double? fontSize}) {
+  final truncated = danaAddress.length <= maxChars
+      ? danaAddress
+      : '${danaAddress.substring(0, maxChars)}...';
+  return Text(
+    truncated,
+    style:
+        BitcoinTextStyle.body4(Bitcoin.neutral7).copyWith(fontSize: fontSize),
+    overflow: TextOverflow.ellipsis,
+    maxLines: 1,
+  );
+}
+
 String displayAddress(BuildContext context, String address, TextStyle style,
     double widthFraction) {
   // split the address into chunks of size 4

--- a/lib/screens/contacts/contact_details.dart
+++ b/lib/screens/contacts/contact_details.dart
@@ -508,9 +508,9 @@ class ContactDetailsScreen extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text(
-                      contact.bip353Address!.toString(),
-                      style: BitcoinTextStyle.body4(Bitcoin.neutral7),
+                    Flexible(
+                      child: danaAddressAsSubtitle(
+                          contact.bip353Address!.toString()),
                     ),
                     const SizedBox(width: 8),
                     Icon(


### PR DESCRIPTION
On contacts details screen, very long bip353 addresses tended to overflow the screen. Added a wrapper for the address that prevents that.