### PR TITLE
refactor: move search contacts to 'add contact' screen

### DIFF
--- a/lib/repositories/contacts_repository.dart
+++ b/lib/repositories/contacts_repository.dart
@@ -106,6 +106,7 @@ class ContactsRepository {
     final db = await _dbHelper.database;
     final maps = await db.query(
       'contacts',
+      orderBy: 'name COLLATE NOCASE ASC',
     );
 
     if (!loadCustomFields) {

--- a/lib/screens/contacts/add_contact_sheet.dart
+++ b/lib/screens/contacts/add_contact_sheet.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
+import 'package:danawallet/data/models/contact.dart';
 import 'package:danawallet/services/bip353_resolver.dart';
+import 'package:danawallet/services/dana_address_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
@@ -33,6 +36,9 @@ class _AddContactSheetState extends State<AddContactSheet> {
   bool _isResolving = false;
   String? _errorMessage;
   bool _hasDanaAddress = false;
+  List<Bip353Address> _remoteDanaAddresses = [];
+  bool _isSearchingRemote = false;
+  Timer? _searchDebounceTimer;
 
   @override
   void initState() {
@@ -45,17 +51,7 @@ class _AddContactSheetState extends State<AddContactSheet> {
     if (widget.initialPaymentCode != null) {
       _paymentCodeController.text = widget.initialPaymentCode!;
     }
-    _bip353AddressController.addListener(() {
-      final hasDanaAddress = _bip353AddressController.text.trim().isNotEmpty;
-      setState(() {
-        _hasDanaAddress = hasDanaAddress;
-      });
-
-      // If dana address is filled, clear SP address field
-      if (hasDanaAddress) {
-        _paymentCodeController.clear();
-      }
-    });
+    _bip353AddressController.addListener(_onDanaAddressChanged);
 
     // Automatically resolve SP address if dana address is provided but SP address is not
     if (widget.initialDanaAddress != null &&
@@ -72,7 +68,99 @@ class _AddContactSheetState extends State<AddContactSheet> {
     _nameController.dispose();
     _bip353AddressController.dispose();
     _paymentCodeController.dispose();
+    _searchDebounceTimer?.cancel();
     super.dispose();
+  }
+
+  void _onDanaAddressChanged() {
+    final query = _bip353AddressController.text.trim();
+    final hasDanaAddress = query.isNotEmpty;
+    setState(() {
+      _hasDanaAddress = hasDanaAddress;
+    });
+
+    // If dana address is filled, clear SP address field
+    if (hasDanaAddress) {
+      _paymentCodeController.clear();
+      _nameController.clear();
+    }
+
+    _searchDebounceTimer?.cancel();
+    if (query.isEmpty) {
+      setState(() {
+        _remoteDanaAddresses = [];
+        _isSearchingRemote = false;
+      });
+      return;
+    }
+
+    if (query.contains('@')) {
+      setState(() {
+        _remoteDanaAddresses = [];
+        _isSearchingRemote = false;
+      });
+      return;
+    }
+
+    final searchPrefix = _extractSearchPrefix(query);
+    if (searchPrefix.length < 3) {
+      setState(() {
+        _remoteDanaAddresses = [];
+        _isSearchingRemote = false;
+      });
+      return;
+    }
+
+    // Debounce remote search to avoid too many API calls
+    _searchDebounceTimer = Timer(const Duration(milliseconds: 500), () {
+      _searchRemoteAddresses(searchPrefix);
+    });
+  }
+
+  String _extractSearchPrefix(String query) {
+    final atIndex = query.indexOf('@');
+    if (atIndex > 0) {
+      return query.substring(0, atIndex).trim();
+    }
+    return query;
+  }
+
+  Future<void> _searchRemoteAddresses(String prefix) async {
+    if (prefix.length < 3) return;
+
+    final knownDanaAddresses =
+        Provider.of<ContactsState>(context, listen: false)
+            .getKnownBip353Addresses();
+
+    setState(() {
+      _isSearchingRemote = true;
+    });
+
+    try {
+      final network = Provider.of<ChainState>(context, listen: false).network;
+      final danaAddresses =
+          await DanaAddressService(network: network).searchPrefix(prefix);
+
+      if (mounted) {
+        final newAddresses = danaAddresses
+            .where((address) => !knownDanaAddresses.contains(address))
+            .take(3)
+            .toList();
+
+        setState(() {
+          _remoteDanaAddresses = newAddresses;
+          _isSearchingRemote = false;
+        });
+      }
+    } catch (e) {
+      Logger().w('Failed to search remote addresses: $e');
+      if (mounted) {
+        setState(() {
+          _remoteDanaAddresses = [];
+          _isSearchingRemote = false;
+        });
+      }
+    }
   }
 
   Future<String?> _resolveDanaAddress() async {
@@ -91,6 +179,9 @@ class _AddContactSheetState extends State<AddContactSheet> {
 
       if (mounted && resolved != null) {
         setState(() {
+          if (_nameController.text.trim().isEmpty) {
+            _nameController.text = parsed.username;
+          }
           _paymentCodeController.text = resolved;
           _isResolving = false;
         });
@@ -111,6 +202,43 @@ class _AddContactSheetState extends State<AddContactSheet> {
       }
     }
     return null;
+  }
+
+  Widget _buildDanaAddressSuggestionItem(Bip353Address danaAddress) {
+    final initial = danaAddress.toString()[0].toUpperCase();
+    const avatarColor = Colors.grey;
+
+    return ListTile(
+      dense: true,
+      leading: CircleAvatar(
+        radius: 16,
+        backgroundColor: avatarColor,
+        child: Text(
+          initial,
+          style:
+              BitcoinTextStyle.body5(Bitcoin.white).apply(fontWeightDelta: 2),
+        ),
+      ),
+      title: Text(
+        danaAddress.toString(),
+        style: BitcoinTextStyle.body5(Bitcoin.black),
+      ),
+      onTap: () async {
+        _searchDebounceTimer?.cancel();
+        setState(() {
+          _remoteDanaAddresses = [];
+          _isSearchingRemote = false;
+          _errorMessage = null;
+        });
+
+        _bip353AddressController.text = danaAddress.toString();
+        if (_nameController.text.trim().isEmpty) {
+          _nameController.text = danaAddress.username;
+        }
+        FocusScope.of(context).unfocus();
+        await _resolveDanaAddress();
+      },
+    );
   }
 
   Future<void> _onSaveContact() async {
@@ -173,6 +301,54 @@ class _AddContactSheetState extends State<AddContactSheet> {
       await Future.delayed(const Duration(milliseconds: 200));
     }
 
+    final existingContact = contactsState.getContactByPaymentCode(paymentCode);
+    if (existingContact != null) {
+      if (mounted &&
+          danaAddress != null &&
+          existingContact.bip353Address == null) {
+        final shouldUpdate = await _showUpdateExistingContactDialog(
+          existingContact,
+          danaAddress,
+        );
+        if (!shouldUpdate) {
+          setState(() {
+            _isSaving = false;
+          });
+          return;
+        }
+        try {
+          final updatedContact = Contact(
+            id: existingContact.id,
+            name: existingContact.name ?? name,
+            bip353Address: danaAddress,
+            paymentCode: existingContact.paymentCode,
+          );
+          await contactsState.updateContact(updatedContact);
+          if (mounted) {
+            Navigator.pop(context, true);
+          }
+          return;
+        } catch (e) {
+          Logger().e('Failed to update contact: $e');
+          if (mounted) {
+            setState(() {
+              _isSaving = false;
+              _errorMessage = 'Failed to update contact: $e';
+            });
+          }
+          return;
+        }
+      }
+
+      if (mounted) {
+        await _showContactAlreadyExistsDialog();
+      }
+      setState(() {
+        _isSaving = false;
+      });
+      return;
+    }
+
     try {
       final network = walletState.network;
 
@@ -195,6 +371,49 @@ class _AddContactSheetState extends State<AddContactSheet> {
         });
       }
     }
+  }
+
+  Future<bool> _showUpdateExistingContactDialog(
+      Contact existingContact, Bip353Address danaAddress) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Contact already exists'),
+            content: Text(
+              'This contact is already saved with the same static address. '
+              'Do you want to add the Dana address (${danaAddress.toString()}) to it?',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Update'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+
+  Future<void> _showContactAlreadyExistsDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Contact already exists'),
+        content: const Text(
+          'This contact is already saved with the same static address.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -257,6 +476,27 @@ class _AddContactSheetState extends State<AddContactSheet> {
                     : null,
               ),
             ),
+            if (_bip353AddressController.text.trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              if (_isSearchingRemote && _remoteDanaAddresses.isEmpty)
+                Text(
+                  'Searching...',
+                  style: BitcoinTextStyle.body5(Bitcoin.neutral6),
+                ),
+              if (_remoteDanaAddresses.isNotEmpty)
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 180),
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: _remoteDanaAddresses.length,
+                    separatorBuilder: (context, index) => const Divider(),
+                    itemBuilder: (context, index) {
+                      return _buildDanaAddressSuggestionItem(
+                          _remoteDanaAddresses[index]);
+                    },
+                  ),
+                ),
+            ],
             const SizedBox(height: 16),
             // Static address field
             TextField(

--- a/lib/screens/contacts/contacts.dart
+++ b/lib/screens/contacts/contacts.dart
@@ -1,15 +1,9 @@
-import 'dart:async';
 import 'package:bitcoin_ui/bitcoin_ui.dart';
-import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/data/models/contact.dart';
-import 'package:danawallet/services/bip353_resolver.dart';
 import 'package:danawallet/screens/contacts/add_contact_sheet.dart';
 import 'package:danawallet/screens/contacts/contact_details.dart';
-import 'package:danawallet/services/dana_address_service.dart';
-import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:flutter/material.dart';
-import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 
 class ContactsScreen extends StatefulWidget {
@@ -21,10 +15,6 @@ class ContactsScreen extends StatefulWidget {
 
 class _ContactsScreenState extends State<ContactsScreen> {
   final TextEditingController _searchController = TextEditingController();
-  List<Bip353Address> _remoteDanaAddresses =
-      []; // Dana addresses from server search
-  bool _isSearchingRemote = false;
-  Timer? _searchDebounceTimer;
 
   @override
   void initState() {
@@ -34,91 +24,14 @@ class _ContactsScreenState extends State<ContactsScreen> {
 
   @override
   void dispose() {
+    _searchController.removeListener(_filterContacts);
     _searchController.dispose();
-    _searchDebounceTimer?.cancel();
     super.dispose();
   }
 
   void _filterContacts() {
-    final query = _searchController.text.trim();
-
-    // Cancel previous timer
-    _searchDebounceTimer?.cancel();
-
-    // Clear remote results if query is empty
-    if (query.isEmpty) {
-      setState(() {
-        _remoteDanaAddresses = [];
-        _isSearchingRemote = false;
-      });
-      return;
-    }
-
-    // Debounce remote search to avoid too many API calls
-    _searchDebounceTimer = Timer(const Duration(milliseconds: 500), () {
-      _searchRemoteAddresses(query);
-    });
-
-    setState(() {
-      // Trigger rebuild to update filtered list
-    });
-  }
-
-  Future<void> _searchRemoteAddresses(String prefix) async {
-    if (prefix.length < 3) return;
-
-    // Get set of existing dana addresses from our contacts
-    final knownDanaAddresses =
-        Provider.of<ContactsState>(context, listen: false)
-            .getKnownBip353Addresses();
-
-    setState(() {
-      _isSearchingRemote = true;
-    });
-
-    try {
-      final network = Provider.of<ChainState>(context, listen: false).network;
-      final danaAddresses =
-          await DanaAddressService(network: network).searchPrefix(prefix);
-
-      if (mounted) {
-        // Filter out addresses that are already in our contacts
-        final newAddresses = danaAddresses
-            .where((address) => !knownDanaAddresses.contains(address))
-            .toList();
-
-        setState(() {
-          _remoteDanaAddresses = newAddresses;
-          _isSearchingRemote = false;
-        });
-      }
-    } catch (e) {
-      Logger().w('Failed to search remote addresses: $e');
-      if (mounted) {
-        setState(() {
-          _remoteDanaAddresses = [];
-          _isSearchingRemote = false;
-        });
-      }
-    }
-  }
-
-  List<Contact> _getFilteredOtherContacts(List<Contact> otherContacts) {
-    final query = _searchController.text.toLowerCase().trim();
-
-    if (query.isEmpty) {
-      return otherContacts;
-    }
-
-    return otherContacts.where((contact) {
-      final displayName = (contact.name ??
-              contact.bip353Address?.toString() ??
-              contact.paymentCode)
-          .toLowerCase();
-      return displayName.contains(query) ||
-          contact.bip353Address != null &&
-              contact.bip353Address!.toString().toLowerCase().contains(query);
-    }).toList();
+    // Trigger rebuild so `_buildSearchResults` re-reads `_searchController.text`.
+    setState(() {});
   }
 
   void _onTapContact(BuildContext context, Contact contact) {
@@ -153,66 +66,6 @@ class _ContactsScreenState extends State<ContactsScreen> {
         onTap: () => _onTapContact(context, contact));
   }
 
-  Widget _buildRemoteAddressItem(Bip353Address danaAddress) {
-    final initial = danaAddress.toString()[0].toUpperCase();
-    const avatarColor = Colors.grey;
-
-    return ListTile(
-      leading: CircleAvatar(
-        radius: 24,
-        backgroundColor: avatarColor,
-        child: Text(
-          initial,
-          style:
-              BitcoinTextStyle.body3(Bitcoin.white).apply(fontWeightDelta: 2),
-        ),
-      ),
-      title: Text(
-        danaAddress.toString(),
-        style: BitcoinTextStyle.body3(Bitcoin.black).apply(fontWeightDelta: 2),
-      ),
-      subtitle: Text(
-        'Not in contacts',
-        style: BitcoinTextStyle.body5(Bitcoin.neutral7),
-      ),
-      onTap: () async {
-        // Resolve SP address and open add contact sheet
-        String? paymentCode;
-        try {
-          final network =
-              Provider.of<ChainState>(context, listen: false).network;
-          final resolved = await Bip353Resolver.resolve(danaAddress, network);
-          if (resolved != null) {
-            paymentCode = resolved;
-          }
-        } catch (e) {
-          Logger().w('Failed to resolve SP address for $danaAddress: $e');
-        }
-
-        if (mounted) {
-          final success = await showModalBottomSheet<bool>(
-            context: context,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder: (context) => AddContactSheet(
-              initialDanaAddress: danaAddress,
-              initialPaymentCode: paymentCode,
-            ),
-          );
-
-          if (success == true) {
-            Logger().d("Added contact: $danaAddress");
-            // clear search on success
-            setState(() {
-              _searchController.clear();
-              _remoteDanaAddresses = [];
-            });
-          }
-        }
-      },
-    );
-  }
-
   void _openAddContactSheet() async {
     await showModalBottomSheet<bool>(
       context: context,
@@ -225,6 +78,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
   @override
   Widget build(BuildContext context) {
     final contactsState = Provider.of<ContactsState>(context);
+    final hasContacts = contactsState.getOtherContactsCount() > 0;
 
     return Scaffold(
       appBar: AppBar(
@@ -249,6 +103,7 @@ class _ContactsScreenState extends State<ContactsScreen> {
             // Search bar
             TextField(
               controller: _searchController,
+              enabled: hasContacts,
               style: BitcoinTextStyle.body4(Bitcoin.black),
               decoration: const InputDecoration(
                 border: OutlineInputBorder(),
@@ -256,14 +111,18 @@ class _ContactsScreenState extends State<ContactsScreen> {
                 hintText: 'Search by name or address',
                 prefixIcon: Icon(Icons.search),
               ),
-              onChanged: (value) {
-                _filterContacts();
-              },
             ),
             const SizedBox(height: 20),
             // List of contacts and remote addresses
             Expanded(
-              child: _buildSearchResults(contactsState.getOtherContacts()),
+              child: !hasContacts
+                  ? Center(
+                      child: Text(
+                        'No contacts yet',
+                        style: BitcoinTextStyle.body3(Bitcoin.neutral6),
+                      ),
+                    )
+                  : _buildSearchResults(contactsState),
             ),
           ],
         ),
@@ -271,80 +130,19 @@ class _ContactsScreenState extends State<ContactsScreen> {
     );
   }
 
-  Widget _buildSearchResults(List<Contact> otherContacts) {
-    final filteredContacts = _getFilteredOtherContacts(otherContacts);
+  Widget _buildSearchResults(ContactsState contactsState) {
+    final query = _searchController.text.toLowerCase().trim();
 
-    final query = _searchController.text.trim();
-    final hasLocalResults = filteredContacts.isNotEmpty;
-    final hasRemoteResults = _remoteDanaAddresses.isNotEmpty;
-    final hasAnyResults = hasLocalResults || hasRemoteResults;
+    final displayContacts = query.length < 3
+        ? contactsState.getOtherContacts()
+        : contactsState.filterContacts(query);
 
-    if (query.isEmpty) {
-      // No search query - show all contacts
-      if (filteredContacts.isEmpty) {
-        return Center(
-          child: Text(
-            otherContacts.isEmpty ? 'No contacts yet' : 'No contacts found',
-            style: BitcoinTextStyle.body3(Bitcoin.neutral6),
-          ),
-        );
-      }
-
-      return ListView.separated(
-        itemCount: filteredContacts.length,
-        separatorBuilder: (context, index) => const Divider(),
-        itemBuilder: (context, index) {
-          return _buildContactItem(filteredContacts[index]);
-        },
-      );
-    }
-
-    // Search query exists
-    if (!hasAnyResults && !_isSearchingRemote) {
-      return Center(
-        child: Text(
-          'No contacts found',
-          style: BitcoinTextStyle.body3(Bitcoin.neutral6),
-        ),
-      );
-    }
-
-    // Build combined list: local contacts first, then remote addresses
-    final List<Widget> items = [];
-
-    // Add local contacts
-    if (hasLocalResults) {
-      for (var contact in filteredContacts) {
-        items.add(_buildContactItem(contact));
-        items.add(const Divider());
-      }
-    }
-
-    // Add remote addresses (not in contacts)
-    if (hasRemoteResults) {
-      for (var address in _remoteDanaAddresses) {
-        items.add(_buildRemoteAddressItem(address));
-        items.add(const Divider());
-      }
-    }
-
-    // Remove last divider if exists
-    if (items.isNotEmpty && items.last is Divider) {
-      items.removeLast();
-    }
-
-    // Show loading indicator if searching remote
-    if (_isSearchingRemote && !hasLocalResults && !hasRemoteResults) {
-      return Center(
-        child: Text(
-          'Searching...',
-          style: BitcoinTextStyle.body3(Bitcoin.neutral6),
-        ),
-      );
-    }
-
-    return ListView(
-      children: items,
+    return ListView.separated(
+      itemCount: displayContacts.length,
+      separatorBuilder: (context, index) => const Divider(),
+      itemBuilder: (context, index) {
+        return _buildContactItem(displayContacts[index]);
+      },
     );
   }
 }

--- a/lib/states/contacts_state.dart
+++ b/lib/states/contacts_state.dart
@@ -146,6 +146,18 @@ class ContactsState extends ChangeNotifier {
     return _contacts;
   }
 
+  int getOtherContactsCount() {
+    return _contacts.length;
+  }
+
+  List<Contact> filterContacts(String query) {
+    return _contacts.where((contact) {
+      final displayName = contact.displayName.toLowerCase();
+      return displayName.contains(query) ||
+          contact.name!.toLowerCase().contains(query);
+    }).toList();
+  }
+
   /// Creates the appropriate display widget for a given silent payment address, using data from the contact list
   /// Priority: contact name > contact dana address > SP address
   /// note: this may not be the best place to put this function, may be refactored out later


### PR DESCRIPTION
We identified UX and security issues with the search contacts feature:
* User could search for contacts they registered and other contacts from the name server at the same place without sufficiently clear distinction
* Add contact form didn't allow searching for unregistered addresses from the name server

That PR cleanly separates the 2 features (searching our contacts vs searching public addresses):
* `ContactsScreen` only search for contacts already registered in our device
* `AddContactSheet` requests name server and returns contacts we haven't registered yet