### PR TITLE
refactor: drop birthday from SpWallet struct

### DIFF
--- a/lib/repositories/wallet_repository.dart
+++ b/lib/repositories/wallet_repository.dart
@@ -84,15 +84,11 @@ class WalletRepository {
     final spendKey = await readSpendKey();
 
     if (scanKey != null && spendKey != null) {
-      // if the scan and spend keys are present, then birthday & network should also be present
-      final birthday = await nonSecureStorage.getInt(_keyBirthday);
+      // if the scan and spend keys are present, then network should also be present
+      // network is required, since we need it to generate the receive & change payment codes
       final network = await readNetwork();
 
-      return SpWallet(
-          scanKey: scanKey,
-          spendKey: spendKey,
-          birthday: birthday!,
-          network: network);
+      return SpWallet(scanKey: scanKey, spendKey: spendKey, network: network);
     } else {
       return null;
     }
@@ -137,6 +133,11 @@ class WalletRepository {
     return TxHistory.decode(encodedHistory: encodedHistory!);
   }
 
+  Future<int> readBirthday() async {
+    final birthday = await nonSecureStorage.getInt(_keyBirthday);
+    return birthday!;
+  }
+
   Future<void> saveLastScan(int lastScan) async {
     await nonSecureStorage.setInt(_keyLastScan, lastScan);
   }
@@ -175,6 +176,7 @@ class WalletRepository {
 
   Future<WalletBackup> createWalletBackup() async {
     final wallet = await readWallet();
+    final birthday = await readBirthday();
     final history = await readHistory();
     final outputs = await readOwnedOutputs();
     final seedPhrase = await readSeedPhrase();
@@ -183,6 +185,7 @@ class WalletRepository {
 
     return WalletBackup(
         wallet: wallet!,
+        birthday: birthday,
         lastScan: lastScan,
         txHistory: history,
         ownedOutputs: outputs,

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -69,7 +69,7 @@ class WalletState extends ChangeNotifier {
   }
 
   Future<bool> initialize() async {
-    // we check if wallet str is present in database
+    // we check if wallet data is present in database
     final wallet = await walletRepository.readWallet();
 
     // if not present, we have no wallet and return false
@@ -77,25 +77,18 @@ class WalletState extends ChangeNotifier {
       return false;
     }
 
+    // since the wallet data is present, the following items must also be present
     network = await walletRepository.readNetwork();
+    birthday = await walletRepository.readBirthday();
     danaAddress = await walletRepository.readDanaAddress();
 
-    // We try to load the wallet data blob.
-    // This may fail if we make a change to the wallet data struct.
-    // This case should crash the app, rather than continue.
-    // If we continue, we risk the user accidentally
-    // deleting their seed phrase.
-    try {
-      receivePaymentCode = wallet.getReceivingAddress();
-      changePaymentCode = wallet.getChangeAddress();
-      birthday = wallet.getBirthday();
+    // we calculate these based on our wallet data (scan key, spend key, network)
+    receivePaymentCode = wallet.getReceivingAddress();
+    changePaymentCode = wallet.getChangeAddress();
 
-      await _updateWalletState();
+    await _updateWalletState();
 
-      return true;
-    } catch (e) {
-      rethrow;
-    }
+    return true;
   }
 
   @override
@@ -110,7 +103,7 @@ class WalletState extends ChangeNotifier {
   }
 
   Future<void> restoreWallet(ApiNetwork network, String mnemonic) async {
-    // set birthday to default wallet
+    // set birthday to default for current network
     final birthday = network.defaultBirthday;
 
     final args = WalletSetupArgs(
@@ -122,7 +115,7 @@ class WalletState extends ChangeNotifier {
     // fill current state variables
     receivePaymentCode = wallet.getReceivingAddress();
     changePaymentCode = wallet.getChangeAddress();
-    this.birthday = wallet.getBirthday();
+    this.birthday = birthday;
     this.network = network;
     await _updateWalletState();
   }
@@ -139,7 +132,7 @@ class WalletState extends ChangeNotifier {
     // fill current state variables
     receivePaymentCode = wallet.getReceivingAddress();
     changePaymentCode = wallet.getChangeAddress();
-    this.birthday = wallet.getBirthday();
+    this.birthday = birthday;
     this.network = network;
     await _updateWalletState();
   }

--- a/rust/src/api/backup.rs
+++ b/rust/src/api/backup.rs
@@ -180,6 +180,7 @@ impl WalletBackup {
     #[frb(sync)]
     pub fn new(
         wallet: SpWallet,
+        birthday: u32,
         network: ApiNetwork,
         tx_history: TxHistory,
         owned_outputs: OwnedOutputs,
@@ -189,7 +190,7 @@ impl WalletBackup {
         Self {
             scan_key: wallet.get_scan_key(),
             spend_key: wallet.get_spend_key(),
-            birthday: wallet.get_birthday(),
+            birthday,
             network,
             tx_history,
             owned_outputs,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -7,35 +7,25 @@ use crate::{api::structs::network::ApiNetwork, wallet::WalletFingerprint};
 use anyhow::Result;
 use flutter_rust_bridge::frb;
 use serde::{Deserialize, Serialize};
-use spdk_core::{
-    bitcoin::{absolute::Height, secp256k1::SecretKey},
-    SpClient, SpendKey,
-};
+use spdk_core::bitcoin::secp256k1::SecretKey;
+use spdk_core::{SpClient, SpendKey};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[frb(opaque)]
 pub struct SpWallet {
     client: SpClient,
     wallet_fingerprint: WalletFingerprint,
-    birthday: Height,
 }
 
 impl SpWallet {
     #[frb(sync)]
-    pub fn new(
-        scan_key: ApiScanKey,
-        spend_key: ApiSpendKey,
-        network: ApiNetwork,
-        birthday: u32,
-    ) -> Result<Self> {
+    pub fn new(scan_key: ApiScanKey, spend_key: ApiSpendKey, network: ApiNetwork) -> Result<Self> {
         let client = SpClient::new(scan_key.into(), spend_key.into(), network.into())?;
 
         let wallet_fingerprint = client.get_client_fingerprint()?;
-        let birthday = Height::from_consensus(birthday)?;
 
         Ok(Self {
             client,
-            birthday,
             wallet_fingerprint,
         })
     }

--- a/rust/src/api/wallet/info.rs
+++ b/rust/src/api/wallet/info.rs
@@ -6,11 +6,6 @@ use super::SpWallet;
 
 impl SpWallet {
     #[frb(sync)]
-    pub fn get_birthday(&self) -> u32 {
-        self.birthday.to_consensus_u32()
-    }
-
-    #[frb(sync)]
     pub fn get_receiving_address(&self) -> String {
         self.client.get_receiving_address().to_string()
     }


### PR DESCRIPTION
This was residue from back when we used to store the json-serialized SpWallet struct in the flutter secure storage directly. Having this makes #243 more difficult, so we remove it here.