### PR TITLE
fix: de/serialize network as lowercase

### DIFF
--- a/rust/src/api/structs/network.rs
+++ b/rust/src/api/structs/network.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use spdk_core::bitcoin;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ApiNetwork {
     Mainnet,
     Testnet3,


### PR DESCRIPTION
This casued issues when storing wallet backups to file.