### PR TITLE
refactor(rust): split OwnedOutput into SimplifiedOutput

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#38d517ea416484ba4109dc02a392fa9c78686756"
+source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#38d517ea416484ba4109dc02a392fa9c78686756"
+source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#38d517ea416484ba4109dc02a392fa9c78686756"
+source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
 dependencies = [
  "anyhow",
  "bdk_coin_select",

--- a/rust/src/api/chain.rs
+++ b/rust/src/api/chain.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
 use log::warn;
 use spdk_wallet::bitcoin;
-use spdk_wallet::ChainBackend;
+use spdk_wallet::chain::ChainBackend;
 use tokio::time::sleep;
 
 use crate::api::structs::network::ApiNetwork;

--- a/rust/src/api/history.rs
+++ b/rust/src/api/history.rs
@@ -107,7 +107,7 @@ impl TxHistory {
                     }
 
                     let entry = txs.entry(outpoint.txid).or_default();
-                    *entry += output.amount;
+                    *entry += output.value;
                 }
                 for (txid, amount) in txs {
                     self.record_incoming_transaction(txid, amount, *blkheight);

--- a/rust/src/api/outputs.rs
+++ b/rust/src/api/outputs.rs
@@ -62,7 +62,7 @@ impl OwnedOutputs {
     pub fn process_state_update(&mut self, update: &StateUpdate) -> Result<()> {
         match update {
             StateUpdate::Update {
-                blkheight: _,
+                blkheight,
                 blkhash,
                 found_outputs,
                 found_inputs,
@@ -74,7 +74,20 @@ impl OwnedOutputs {
                 }
 
                 // record the outputs
-                self.0.extend(found_outputs.clone());
+                self.0
+                    .extend(found_outputs.iter().map(|(outpoint, output)| {
+                        (
+                            *outpoint,
+                            OwnedOutput {
+                                blockheight: *blkheight,
+                                spend_status: OutputSpendStatus::Unspent,
+                                tweak: output.tweak.to_be_bytes(),
+                                amount: output.value,
+                                script: output.script_pubkey.clone(),
+                                label: output.label.clone(),
+                            },
+                        )
+                    }))
             }
             StateUpdate::NoUpdate { .. } => (),
         }

--- a/rust/src/api/wallet/scan.rs
+++ b/rust/src/api/wallet/scan.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use backend_blindbit_v1::BlindbitBackend;
 use spdk_wallet::bitcoin;
+use spdk_wallet::chain::ChainBackend;
 use spdk_wallet::scanner::SpScanner;
-use spdk_wallet::ChainBackend;
 
 use crate::{api::outputs::OwnedOutPoints, state::StateUpdater, wallet::KEEP_SCANNING};
 

--- a/rust/src/state/updater.rs
+++ b/rust/src/state/updater.rs
@@ -3,9 +3,11 @@ use std::{
     mem,
 };
 
-use spdk_wallet::bitcoin::{absolute::Height, BlockHash, OutPoint};
-use spdk_wallet::client::OwnedOutput;
-use spdk_wallet::Updater;
+use spdk_wallet::updater::Updater;
+use spdk_wallet::{
+    bitcoin::{absolute::Height, BlockHash, OutPoint},
+    updater::SimplifiedOutput,
+};
 
 use crate::stream::{send_scan_progress, send_state_update, ScanProgress, StateUpdate};
 
@@ -15,7 +17,7 @@ pub struct StateUpdater {
     update: bool,
     blkhash: Option<BlockHash>,
     blkheight: Option<Height>,
-    found_outputs: HashMap<OutPoint, OwnedOutput>,
+    found_outputs: HashMap<OutPoint, SimplifiedOutput>,
     found_inputs: HashSet<OutPoint>,
 }
 
@@ -76,7 +78,7 @@ impl Updater for StateUpdater {
         &mut self,
         height: Height,
         blkhash: BlockHash,
-        found_outputs: HashMap<OutPoint, OwnedOutput>,
+        found_outputs: HashMap<OutPoint, SimplifiedOutput>,
     ) -> Result<()> {
         // may have already been written by record_block_inputs
         self.update = true;

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -5,8 +5,10 @@ use std::{
 
 use crate::frb_generated::StreamSink;
 use lazy_static::lazy_static;
-use spdk_wallet::bitcoin::{absolute::Height, BlockHash, OutPoint};
-use spdk_wallet::client::OwnedOutput;
+use spdk_wallet::{
+    bitcoin::{absolute::Height, BlockHash, OutPoint},
+    updater::SimplifiedOutput,
+};
 
 lazy_static! {
     static ref SCAN_PROGRESS_STREAM_SINK: Mutex<Option<StreamSink<ScanProgress>>> =
@@ -22,7 +24,7 @@ pub enum StateUpdate {
     Update {
         blkheight: Height,
         blkhash: BlockHash,
-        found_outputs: HashMap<OutPoint, OwnedOutput>,
+        found_outputs: HashMap<OutPoint, SimplifiedOutput>,
         found_inputs: HashSet<OutPoint>,
     },
 }


### PR DESCRIPTION
Solves spdk issue https://github.com/cygnet3/spdk/issues/98, which basically tied us to having a Update trait-defined struct for the owned output. 