### PR TITLE
refactor(rust): import backend-blindbit-v1 via spdk_wallet re-export

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
+source = "git+https://github.com/cygnet3/spdk?branch=master#ca6fbbeaeeaac756f05fb2ccc5ec3b60d2ceb0ab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1730,7 +1730,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "backend-blindbit-v1",
  "base64 0.22.1",
  "bip39",
  "flutter_rust_bridge",
@@ -1961,8 +1960,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "silentpayments"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d42e3050dd88c79e4849b27eaf0cda0625f4e910d97bf05044a1300459f85"
+source = "git+https://github.com/cygnet3/spdk?branch=master#ca6fbbeaeeaac756f05fb2ccc5ec3b60d2ceb0ab"
 dependencies = [
  "bech32 0.9.1",
  "bimap",
@@ -2022,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
+source = "git+https://github.com/cygnet3/spdk?branch=master#ca6fbbeaeeaac756f05fb2ccc5ec3b60d2ceb0ab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2035,9 +2033,10 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#84e5a350fe571d07ae318241819e3093692920b4"
+source = "git+https://github.com/cygnet3/spdk?branch=master#ca6fbbeaeeaac756f05fb2ccc5ec3b60d2ceb0ab"
 dependencies = [
  "anyhow",
+ "backend-blindbit-v1",
  "bdk_coin_select",
  "bitcoin 0.32.8",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 flutter_rust_bridge = "=2.11.1"
 spdk-wallet = { git = "https://github.com/cygnet3/spdk", branch = "master" }
-backend-blindbit-v1 = { git = "https://github.com/cygnet3/spdk", branch = "master" }
 lazy_static = "1.4"
 anyhow = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/rust/src/api/chain.rs
+++ b/rust/src/api/chain.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
 use log::warn;
+use spdk_wallet::backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
 use spdk_wallet::bitcoin;
 use spdk_wallet::chain::ChainBackend;
 use tokio::time::sleep;

--- a/rust/src/api/wallet/scan.rs
+++ b/rust/src/api/wallet/scan.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use backend_blindbit_v1::BlindbitBackend;
+use spdk_wallet::backend_blindbit_v1::BlindbitBackend;
 use spdk_wallet::bitcoin;
 use spdk_wallet::chain::ChainBackend;
 use spdk_wallet::scanner::SpScanner;

--- a/rust/src/api/wallet/transaction.rs
+++ b/rust/src/api/wallet/transaction.rs
@@ -6,8 +6,8 @@ use crate::api::structs::recipient::ApiRecipient;
 use crate::api::structs::unsigned_transaction::ApiSilentPaymentUnsignedTransaction;
 
 use anyhow::Result;
-use backend_blindbit_v1::BlindbitClient;
 use bip39::rand::{thread_rng, RngCore};
+use spdk_wallet::backend_blindbit_v1::BlindbitClient;
 use spdk_wallet::bitcoin::{consensus::serialize, hex::DisplayHex, OutPoint};
 use spdk_wallet::client::{FeeRate, OwnedOutput, Recipient, RecipientAddress, SpClient};
 


### PR DESCRIPTION
Import the blindbit backend via the spdk-wallet re-export, which is behind an optional feature that is enabled by default. This way we don't need to specify both dependencies.