### PR TITLE
refactor: Move `display_btc` and `display_sats` from rust code to dart

### DIFF
--- a/lib/data/enums/fiat_currency.dart
+++ b/lib/data/enums/fiat_currency.dart
@@ -59,4 +59,3 @@ enum FiatCurrency {
     }
   }
 }
-

--- a/lib/extensions/api_amount.dart
+++ b/lib/extensions/api_amount.dart
@@ -1,7 +1,19 @@
+import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 
 extension ApiAmountExtension on ApiAmount {
   ApiAmount operator +(ApiAmount other) {
     return ApiAmount(field0: field0 + other.field0);
+  }
+
+  String displayBtc() {
+    final btcPart = field0 ~/ BigInt.from(bitcoinUnits);
+    final satsPart = (field0 % BigInt.from(bitcoinUnits));
+    final satsStr = satsPart.toString().padLeft(8, '0');
+    return '₿ $btcPart.${satsStr.substring(0, 2)} ${satsStr.substring(2, 5)} ${satsStr.substring(5, 8)}';
+  }
+
+  String displaySats() {
+    return '$field0 sats';
   }
 }

--- a/lib/screens/contacts/contact_details.dart
+++ b/lib/screens/contacts/contact_details.dart
@@ -2,6 +2,7 @@ import 'package:barcode_widget/barcode_widget.dart';
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
+import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/data/models/contact.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
 import 'package:danawallet/generated/rust/api/structs/recorded_transaction.dart';

--- a/lib/screens/spend/amount_selection.dart
+++ b/lib/screens/spend/amount_selection.dart
@@ -1,6 +1,7 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
+import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/extensions/payment_code.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 import 'package:danawallet/screens/spend/fee_selection.dart';

--- a/lib/screens/spend/custom_fee_screen.dart
+++ b/lib/screens/spend/custom_fee_screen.dart
@@ -1,5 +1,6 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
+import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/data/models/recipient_form_filled.dart';
 import 'package:danawallet/data/enums/selected_fee.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';

--- a/lib/screens/spend/fee_selection.dart
+++ b/lib/screens/spend/fee_selection.dart
@@ -1,5 +1,6 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
+import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/data/models/recipient_form_filled.dart';
 import 'package:danawallet/data/enums/selected_fee.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';

--- a/lib/screens/spend/ready_to_send.dart
+++ b/lib/screens/spend/ready_to_send.dart
@@ -1,5 +1,6 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/data/models/recipient_form.dart';
+import 'package:danawallet/extensions/api_amount.dart';
 import 'package:danawallet/extensions/payment_code.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';

--- a/rust/src/api/structs/amount.rs
+++ b/rust/src/api/structs/amount.rs
@@ -1,4 +1,3 @@
-use flutter_rust_bridge::frb;
 use serde::{Deserialize, Serialize};
 use spdk_wallet::bitcoin;
 
@@ -14,30 +13,5 @@ impl From<bitcoin::Amount> for ApiAmount {
 impl From<ApiAmount> for bitcoin::Amount {
     fn from(value: ApiAmount) -> bitcoin::Amount {
         bitcoin::Amount::from_sat(value.0)
-    }
-}
-
-impl ApiAmount {
-    #[frb(sync)]
-    pub fn to_int(&self) -> u64 {
-        self.0
-    }
-
-    #[frb(sync)]
-    pub fn display_btc(&self) -> String {
-        let amount_btc = self.0 as f32 / 100_000_000 as f32;
-        let decimals = format!("{:.8}", amount_btc);
-        let len = decimals.len();
-        format!(
-            "₿ {} {} {}",
-            &decimals[..len - 6],
-            &decimals[len - 6..len - 3],
-            &decimals[len - 3..]
-        )
-    }
-
-    #[frb(sync)]
-    pub fn display_sats(&self) -> String {
-        format!("{} sats", self.0)
     }
 }

--- a/rust/src/api/structs/unsigned_transaction.rs
+++ b/rust/src/api/structs/unsigned_transaction.rs
@@ -100,10 +100,10 @@ impl ApiSilentPaymentUnsignedTransaction {
         let input_sum: u64 = self
             .selected_utxos
             .iter()
-            .map(|(_, o)| o.amount.to_int())
+            .map(|(_, o)| o.amount.0)
             .sum();
 
-        let output_sum: u64 = self.recipients.iter().map(|r| r.amount.to_int()).sum();
+        let output_sum: u64 = self.recipients.iter().map(|r| r.amount.0).sum();
 
         ApiAmount(input_sum - output_sum)
     }


### PR DESCRIPTION
Very limited PR that simply moves the display code from rust to dart without modifying existing type. The `to_int` method was also deleted because it was used in a non systematic way and basically useless anyway