### PR TITLE
refactor(blindbit): call block-height on client directly

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#61e6fe54de9eed8cb2d60342caec3b4c429d10f8"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1960,7 +1960,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "silentpayments"
 version = "0.5.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#61e6fe54de9eed8cb2d60342caec3b4c429d10f8"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
 dependencies = [
  "bech32 0.9.1",
  "bimap",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#61e6fe54de9eed8cb2d60342caec3b4c429d10f8"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#61e6fe54de9eed8cb2d60342caec3b4c429d10f8"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
 dependencies = [
  "anyhow",
  "backend-blindbit-v1",

--- a/rust/src/api/chain.rs
+++ b/rust/src/api/chain.rs
@@ -3,15 +3,14 @@ use std::time::Duration;
 use log::warn;
 use spdk_wallet::backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
 use spdk_wallet::bitcoin;
-use spdk_wallet::chain::ChainBackend;
 use tokio::time::sleep;
 
 use crate::api::structs::network::ApiNetwork;
 
 pub async fn get_chain_height(blindbit_url: String) -> anyhow::Result<u32> {
-    let backend = BlindbitBackend::new(blindbit_url)?;
+    let client = BlindbitClient::new(&blindbit_url)?;
 
-    match backend.block_height().await {
+    match client.block_height().await {
         Ok(res) => Ok(res.to_consensus_u32()),
         Err(e) => {
             if e.root_cause()
@@ -23,7 +22,7 @@ pub async fn get_chain_height(blindbit_url: String) -> anyhow::Result<u32> {
                 // sleep for 1 second
                 sleep(Duration::from_millis(1000)).await;
 
-                Ok(backend.block_height().await?.to_consensus_u32())
+                Ok(client.block_height().await?.to_consensus_u32())
             } else {
                 Err(e)
             }
@@ -33,7 +32,7 @@ pub async fn get_chain_height(blindbit_url: String) -> anyhow::Result<u32> {
 
 pub async fn check_network(blindbit_url: String, network: ApiNetwork) -> anyhow::Result<bool> {
     let network: bitcoin::Network = network.into();
-    let client = BlindbitClient::new(blindbit_url)?;
+    let client = BlindbitClient::new(&blindbit_url)?;
 
     let blindbit_network = client.info().await?.network;
 

--- a/rust/src/api/wallet/scan.rs
+++ b/rust/src/api/wallet/scan.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use spdk_wallet::backend_blindbit_v1::BlindbitBackend;
+use spdk_wallet::backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
 use spdk_wallet::bitcoin;
-use spdk_wallet::chain::ChainBackend;
 use spdk_wallet::scanner::SpScanner;
 
 use crate::{api::outputs::OwnedOutPoints, state::StateUpdater, wallet::KEEP_SCANNING};
@@ -24,12 +23,13 @@ impl SpWallet {
         dust_limit: u64,
         owned_outpoints: OwnedOutPoints,
     ) -> Result<()> {
-        let backend = BlindbitBackend::new(blindbit_url)?;
+        let client = BlindbitClient::new(&blindbit_url)?;
+        let backend = BlindbitBackend::new(client.clone());
 
         let dust_limit = bitcoin::Amount::from_sat(dust_limit);
 
         let start = bitcoin::absolute::Height::from_consensus(last_scan + 1)?;
-        let end = backend.block_height().await?;
+        let end = client.block_height().await?;
 
         let sp_client = self.client.clone();
         let updater = StateUpdater::new();

--- a/rust/src/api/wallet/transaction.rs
+++ b/rust/src/api/wallet/transaction.rs
@@ -98,7 +98,7 @@ impl SpWallet {
 
     // note: should only be used when using regtest, else there is privacy loss!
     pub async fn broadcast_using_blindbit(blindbit_url: String, tx: String) -> Result<String> {
-        let blindbit_client = BlindbitClient::new(blindbit_url)?;
+        let blindbit_client = BlindbitClient::new(&blindbit_url)?;
 
         let res = blindbit_client.forward_tx(tx).await?;
 


### PR DESCRIPTION
Don't use the blindbit backend trait to fetch the block height, and use the client directly instead.