### PR TITLE
refactor(sync): track sync start and end in sync service

### DIFF
--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -97,7 +97,9 @@ class SynchronizationService {
     if (walletState.lastScan! < chainState.tip) {
       if (!scanProgress.scanning) {
         Logger().i("Starting sync");
-        await scanProgress.scan(walletState);
+        final start = walletState.lastScan!;
+        final end = chainState.tip;
+        await scanProgress.scan(walletState, start, end);
       }
     }
 

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -11,7 +11,8 @@ import 'package:flutter/material.dart';
 class ScanProgressNotifier extends ChangeNotifier {
   Completer? _completer;
   double progress = 0.0;
-  int current = 0;
+  late int start;
+  late int end;
 
   late StreamSubscription scanProgressSubscription;
 
@@ -21,10 +22,7 @@ class ScanProgressNotifier extends ChangeNotifier {
   ScanProgressNotifier._();
 
   Future<void> _initialize() async {
-    scanProgressSubscription = createScanProgressStream().listen(((event) {
-      int start = event.start;
-      current = event.current;
-      int end = event.end;
+    scanProgressSubscription = createScanProgressStream().listen(((current) {
       double scanned = (current - start).toDouble();
       double total = (end - start).toDouble();
       double progress = scanned / total;
@@ -48,10 +46,9 @@ class ScanProgressNotifier extends ChangeNotifier {
     super.dispose();
   }
 
-  void activate(int start) {
+  void activate() {
     _completer = Completer();
     progress = 0.0;
-    current = start;
     notifyListeners();
   }
 
@@ -61,7 +58,10 @@ class ScanProgressNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> scan(WalletState walletState) async {
+  Future<void> scan(WalletState walletState, int start, int end) async {
+    this.start = start;
+    this.end = end;
+
     try {
       final wallet = await walletState.getWalletFromSecureStorage();
       final settings = SettingsRepository.instance;
@@ -76,7 +76,7 @@ class ScanProgressNotifier extends ChangeNotifier {
       final ownedOutPoints =
           walletState.ownedOutputs.getUnconfirmedSpentOutpoints();
 
-      activate(walletState.lastScan!);
+      activate();
       await wallet.scanToTip(
           blindbitUrl: blindbitUrl,
           dustLimit: BigInt.from(dustLimit),

--- a/rust/src/api/stream.rs
+++ b/rust/src/api/stream.rs
@@ -1,7 +1,7 @@
 use crate::{
     frb_generated::StreamSink,
     logger::{self, LogEntry, LogLevel},
-    stream::{self, ScanProgress, StateUpdate},
+    stream::{self, StateUpdate},
 };
 
 #[flutter_rust_bridge::frb(sync)]
@@ -11,7 +11,7 @@ pub fn create_log_stream(s: StreamSink<LogEntry>, level: LogLevel, log_dependenc
 }
 
 #[flutter_rust_bridge::frb(sync)]
-pub fn create_scan_progress_stream(s: StreamSink<ScanProgress>) {
+pub fn create_scan_progress_stream(s: StreamSink<u32>) {
     stream::create_scan_progress_stream(s);
 }
 

--- a/rust/src/state/updater.rs
+++ b/rust/src/state/updater.rs
@@ -9,7 +9,7 @@ use spdk_wallet::{
     updater::DiscoveredOutput,
 };
 
-use crate::stream::{send_scan_progress, send_state_update, ScanProgress, StateUpdate};
+use crate::stream::{send_scan_progress, send_state_update, StateUpdate};
 
 use anyhow::Result;
 
@@ -62,14 +62,15 @@ impl StateUpdater {
 }
 
 impl Updater for StateUpdater {
-    fn record_scan_progress(&mut self, start: Height, current: Height, end: Height) -> Result<()> {
+    fn record_scan_progress(
+        &mut self,
+        _start: Height,
+        current: Height,
+        _end: Height,
+    ) -> Result<()> {
         self.blkheight = Some(current);
 
-        send_scan_progress(ScanProgress {
-            start: start.to_consensus_u32(),
-            current: current.to_consensus_u32(),
-            end: end.to_consensus_u32(),
-        });
+        send_scan_progress(current.to_consensus_u32());
 
         Ok(())
     }

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -11,8 +11,7 @@ use spdk_wallet::{
 };
 
 lazy_static! {
-    static ref SCAN_PROGRESS_STREAM_SINK: Mutex<Option<StreamSink<ScanProgress>>> =
-        Mutex::new(None);
+    static ref SCAN_PROGRESS_STREAM_SINK: Mutex<Option<StreamSink<u32>>> = Mutex::new(None);
     static ref STATE_UPDATE_STREAM_SINK: Mutex<Option<StreamSink<StateUpdate>>> = Mutex::new(None);
 }
 
@@ -29,13 +28,7 @@ pub enum StateUpdate {
     },
 }
 
-pub struct ScanProgress {
-    pub start: u32,
-    pub current: u32,
-    pub end: u32,
-}
-
-pub fn create_scan_progress_stream(s: StreamSink<ScanProgress>) {
+pub fn create_scan_progress_stream(s: StreamSink<u32>) {
     let mut stream_sink = SCAN_PROGRESS_STREAM_SINK.lock().unwrap();
     *stream_sink = Some(s);
 }
@@ -45,7 +38,7 @@ pub fn create_scan_update_stream(s: StreamSink<StateUpdate>) {
     *stream_sink = Some(s);
 }
 
-pub(crate) fn send_scan_progress(scan_progress: ScanProgress) {
+pub(crate) fn send_scan_progress(scan_progress: u32) {
     let stream_sink = SCAN_PROGRESS_STREAM_SINK.lock().unwrap();
     if let Some(stream_sink) = stream_sink.as_ref() {
         stream_sink.add(scan_progress).unwrap();


### PR DESCRIPTION
Drop support for the start and end heights in the sync progress update stream. We should track these values on the caller side and only read the progress updates in the form of a 'current' block height.

This allows us (in the future) to keep sync progress in between multiple syncs, instead of resetting the 'sync progress' bar to zero.