### PR TITLE
feat(sync): replace scan_to_tip with sync_to_height

### DIFF
--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -98,8 +98,8 @@ class SynchronizationService {
       if (!scanProgress.scanning) {
         Logger().i("Starting sync");
         final start = walletState.lastScan!;
-        final end = chainState.tip;
-        await scanProgress.scan(walletState, start, end);
+        final chainTip = chainState.tip;
+        await scanProgress.scan(walletState, start, chainTip);
       }
     }
 

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -58,9 +58,12 @@ class ScanProgressNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> scan(WalletState walletState, int start, int end) async {
+  Future<void> scan(WalletState walletState, int start, int chainTip) async {
     this.start = start;
-    this.end = end;
+    end = chainTip;
+
+    // start syncing from the first block after our last sync
+    final fromHeight = walletState.lastScan! + 1;
 
     try {
       final wallet = await walletState.getWalletFromSecureStorage();
@@ -77,11 +80,13 @@ class ScanProgressNotifier extends ChangeNotifier {
           walletState.ownedOutputs.getUnconfirmedSpentOutpoints();
 
       activate();
-      await wallet.scanToTip(
-          blindbitUrl: blindbitUrl,
-          dustLimit: BigInt.from(dustLimit),
-          ownedOutpoints: ownedOutPoints,
-          lastScan: walletState.lastScan!);
+      await wallet.syncToHeight(
+        fromHeight: fromHeight,
+        toHeight: chainTip,
+        blindbitUrl: blindbitUrl,
+        dustLimit: BigInt.from(dustLimit),
+        ownedOutpoints: ownedOutPoints,
+      );
     } catch (e) {
       deactivate();
       rethrow;

--- a/rust/src/api/wallet/scan.rs
+++ b/rust/src/api/wallet/scan.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use spdk_wallet::backend_blindbit_v1::{BlindbitBackend, BlindbitClient};
-use spdk_wallet::bitcoin;
+use spdk_wallet::bitcoin::absolute::Height;
+use spdk_wallet::bitcoin::Amount;
 use spdk_wallet::scanner::SpScanner;
 
 use crate::{api::outputs::OwnedOutPoints, state::StateUpdater, wallet::KEEP_SCANNING};
@@ -16,20 +17,21 @@ impl SpWallet {
         KEEP_SCANNING.store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
-    pub async fn scan_to_tip(
+    pub async fn sync_to_height(
         &self,
+        from_height: u32,
+        to_height: u32,
         blindbit_url: String,
-        last_scan: u32,
         dust_limit: u64,
         owned_outpoints: OwnedOutPoints,
     ) -> Result<()> {
         let client = BlindbitClient::new(&blindbit_url)?;
-        let backend = BlindbitBackend::new(client.clone());
+        let backend = BlindbitBackend::new(client);
 
-        let dust_limit = bitcoin::Amount::from_sat(dust_limit);
+        let dust_limit = Amount::from_sat(dust_limit);
 
-        let start = bitcoin::absolute::Height::from_consensus(last_scan + 1)?;
-        let end = client.block_height().await?;
+        let start = Height::from_consensus(from_height)?;
+        let end = Height::from_consensus(to_height)?;
 
         let sp_client = self.client.clone();
         let updater = StateUpdater::new();


### PR DESCRIPTION
Replace SpWallet scan_to_tip, which fetches the current chain tip using the backend, with sync_to_height. This way we make sure we sync to the known tip in the ChainState.