### PR TITLE
feat(sync): track total sync progress in between sync attempts

### DIFF
--- a/lib/screens/settings/network/network_settings_screen.dart
+++ b/lib/screens/settings/network/network_settings_screen.dart
@@ -51,12 +51,14 @@ class NetworkSettingsScreen extends StatelessWidget {
         'Enter current scan height (numeric value)');
     if (scanHeight is int) {
       await walletState.resetToScanHeight(scanHeight);
+      chainState.clearSyncHistory();
       homeState.showMainScreen();
     } else if (scanHeight is bool && scanHeight) {
       final birthday = walletState.birthday;
       // TODO probably better and simpler to set lastScan to null and let the synchronization service set it to the birthday height
       final height = await chainState.getBlockHeightFromDate(birthday!);
       await walletState.resetToScanHeight(height);
+      chainState.clearSyncHistory();
       homeState.showMainScreen();
     }
   }

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -130,4 +130,8 @@ class SynchronizationService {
     Logger().i("Stopping sync service");
     _timer?.cancel();
   }
+
+  void clearSyncHistory() {
+    _startHeight = null;
+  }
 }

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -13,6 +13,12 @@ class SynchronizationService {
   ChainState chainState;
   ScanProgressNotifier scanProgress;
 
+  // first sync will set the start height, all other syncs will keep the same height
+  // this is useful if we receive an error while syncing, and restart the sync process.
+  // this way, we make it explicit that we're continuing from the last sync,
+  // instead of completely restarting.
+  int? _startHeight;
+
   Timer? _timer;
   final Duration _interval = const Duration(seconds: 10);
 
@@ -97,9 +103,11 @@ class SynchronizationService {
     if (walletState.lastScan! < chainState.tip) {
       if (!scanProgress.scanning) {
         Logger().i("Starting sync");
-        final start = walletState.lastScan!;
-        final chainTip = chainState.tip;
-        await scanProgress.scan(walletState, start, chainTip);
+
+        // set start height if not yet set
+        _startHeight ??= walletState.lastScan!;
+
+        await scanProgress.scan(walletState, _startHeight!, chainState.tip);
       }
     }
 

--- a/lib/states/chain_state.dart
+++ b/lib/states/chain_state.dart
@@ -83,6 +83,10 @@ class ChainState extends ChangeNotifier {
     }
   }
 
+  void clearSyncHistory() {
+    _synchronizationService.clearSyncHistory();
+  }
+
   void reset() {
     _synchronizationService.stopSyncTimer();
     _tip = null;
@@ -152,7 +156,8 @@ class ChainState extends ChangeNotifier {
 
   Future<int> getBlockHeightFromDate(DateTime date) async {
     final mempoolApiRepository = MempoolApiRepository(network: network);
-    final block = await mempoolApiRepository.getBlockFromTimestamp(date.toSeconds());
+    final block =
+        await mempoolApiRepository.getBlockFromTimestamp(date.toSeconds());
     return block.height;
   }
 }

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -58,7 +58,8 @@ class ScanProgressNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> scan(WalletState walletState, int startHeight, int chainTip) async {
+  Future<void> scan(
+      WalletState walletState, int startHeight, int chainTip) async {
     this.startHeight = startHeight;
     endHeight = chainTip;
 

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -11,8 +11,8 @@ import 'package:flutter/material.dart';
 class ScanProgressNotifier extends ChangeNotifier {
   Completer? _completer;
   double progress = 0.0;
-  late int start;
-  late int end;
+  late int startHeight;
+  late int endHeight;
 
   late StreamSubscription scanProgressSubscription;
 
@@ -23,10 +23,10 @@ class ScanProgressNotifier extends ChangeNotifier {
 
   Future<void> _initialize() async {
     scanProgressSubscription = createScanProgressStream().listen(((current) {
-      double scanned = (current - start).toDouble();
-      double total = (end - start).toDouble();
+      double scanned = (current - startHeight).toDouble();
+      double total = (endHeight - startHeight).toDouble();
       double progress = scanned / total;
-      if (current != end) {
+      if (current != endHeight) {
         this.progress = progress;
 
         notifyListeners();
@@ -58,12 +58,14 @@ class ScanProgressNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> scan(WalletState walletState, int start, int chainTip) async {
-    this.start = start;
-    end = chainTip;
+  Future<void> scan(WalletState walletState, int startHeight, int chainTip) async {
+    this.startHeight = startHeight;
+    endHeight = chainTip;
 
     // start syncing from the first block after our last sync
+    // we ignore the startHeight here, because we may be continuing from another sync
     final fromHeight = walletState.lastScan! + 1;
+    final toHeight = chainTip;
 
     try {
       final wallet = await walletState.getWalletFromSecureStorage();
@@ -82,7 +84,7 @@ class ScanProgressNotifier extends ChangeNotifier {
       activate();
       await wallet.syncToHeight(
         fromHeight: fromHeight,
-        toHeight: chainTip,
+        toHeight: toHeight,
         blindbitUrl: blindbitUrl,
         dustLimit: BigInt.from(dustLimit),
         ownedOutpoints: ownedOutPoints,


### PR DESCRIPTION
If a previous sync has errored before completing, we try again after a couple of seconds. However when we retry, we should make sure to indicate that we're continuing from the last point instead of restarting. We do this by recording the lastScan for the first sync we do, and re-use this value as the start height for later syncs.