### PR TITLE
feat(sync, UI): show generic load bar when starting sync

### DIFF
--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -48,8 +48,14 @@ class WalletScreenState extends State<WalletScreen> {
     return Row(
       children: [
         if (scanProgress != null)
-          Text('Scanning: ${(scanProgress * 100.0).toStringAsFixed(0)} %  ',
-              style: BitcoinTextStyle.body5(Bitcoin.neutral7)),
+          SizedBox(
+              width: 40,
+              child: Text('${(scanProgress * 100.0).toStringAsFixed(0)} %',
+                  textAlign: TextAlign.right,
+                  style: BitcoinTextStyle.body5(Bitcoin.neutral7))),
+        const SizedBox(
+          width: 5,
+        ),
         Expanded(
           child: ClipRRect(
               borderRadius: BorderRadius.circular(8),

--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -44,11 +44,12 @@ class WalletScreenState extends State<WalletScreen> {
     });
   }
 
-  Widget buildScanProgress(double scanProgress) {
+  Widget buildScanProgress(double? scanProgress) {
     return Row(
       children: [
-        Text('Scanning: ${(scanProgress * 100.0).toStringAsFixed(0)} %  ',
-            style: BitcoinTextStyle.body5(Bitcoin.neutral7)),
+        if (scanProgress != null)
+          Text('Scanning: ${(scanProgress * 100.0).toStringAsFixed(0)} %  ',
+              style: BitcoinTextStyle.body5(Bitcoin.neutral7)),
         Expanded(
           child: ClipRRect(
               borderRadius: BorderRadius.circular(8),
@@ -471,7 +472,7 @@ class WalletScreenState extends State<WalletScreen> {
         children: [
           // Show sync progress when actively scanning
           Visibility(
-              visible: scanProgress.scanning,
+              visible: scanProgress.isScanning,
               maintainAnimation: true,
               maintainSize: true,
               maintainState: true,
@@ -547,7 +548,7 @@ class WalletScreenState extends State<WalletScreen> {
     );
   }
 
-  AppBar buildAppBar(bool isScanning, Color networkColor) {
+  AppBar buildAppBar(Color networkColor) {
     return AppBar(
       forceMaterialTransparency: true,
       title: Row(
@@ -587,7 +588,7 @@ class WalletScreenState extends State<WalletScreen> {
     bool showFundingScreen = isBalanceZero && !hasTransactionHistory;
 
     return Scaffold(
-        appBar: buildAppBar(scanProgress.scanning, walletState.network.toColor),
+        appBar: buildAppBar(walletState.network.toColor),
         body: showFundingScreen
             ? buildFundingScreen(
                 walletState.receivePaymentCode,
@@ -605,7 +606,7 @@ class WalletScreenState extends State<WalletScreen> {
                         children: [
                           // Show sync progress when actively scanning
                           Visibility(
-                              visible: scanProgress.scanning,
+                              visible: scanProgress.isScanning,
                               maintainAnimation: true,
                               maintainSize: true,
                               maintainState: true,

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -101,7 +101,7 @@ class SynchronizationService {
     }
 
     if (walletState.lastScan! < chainState.tip) {
-      if (!scanProgress.scanning) {
+      if (!scanProgress.isScanning) {
         Logger().i("Starting sync");
 
         // set start height if not yet set

--- a/lib/states/scan_progress_notifier.dart
+++ b/lib/states/scan_progress_notifier.dart
@@ -10,13 +10,13 @@ import 'package:flutter/material.dart';
 
 class ScanProgressNotifier extends ChangeNotifier {
   Completer? _completer;
-  double progress = 0.0;
+  double? progress;
   late int startHeight;
   late int endHeight;
 
   late StreamSubscription scanProgressSubscription;
 
-  bool get scanning => _completer != null && !_completer!.isCompleted;
+  bool get isScanning => _completer != null && !_completer!.isCompleted;
 
   // private constructor
   ScanProgressNotifier._();
@@ -48,13 +48,13 @@ class ScanProgressNotifier extends ChangeNotifier {
 
   void activate() {
     _completer = Completer();
-    progress = 0.0;
+    progress = null;
     notifyListeners();
   }
 
   void deactivate() {
     _completer?.complete();
-    progress = 0.0;
+    progress = null;
     notifyListeners();
   }
 
@@ -98,7 +98,7 @@ class ScanProgressNotifier extends ChangeNotifier {
   }
 
   Future<void> interruptScan() async {
-    if (scanning) {
+    if (isScanning) {
       SpWallet.interruptScanning();
 
       // this makes sure the scan function has been terminated


### PR DESCRIPTION
Instead of initializing a sync value of 0%, keep this value null and
only show a progress percentage once we've received the first update.