### PR TITLE
refactor(sync, rust): simplify updater trait

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
+source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1960,7 +1960,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "silentpayments"
 version = "0.5.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
+source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
 dependencies = [
  "bech32 0.9.1",
  "bimap",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
+source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#b2646f69307a3f3044cee8ee93620b052440128d"
+source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
 dependencies = [
  "anyhow",
  "backend-blindbit-v1",

--- a/rust/src/api/history.rs
+++ b/rust/src/api/history.rs
@@ -54,66 +54,63 @@ impl TxHistory {
         update: &StateUpdate,
         owned_outputs: &OwnedOutputs,
     ) -> Result<()> {
-        match update {
-            StateUpdate::Update {
-                blkheight,
-                blkhash: _,
-                found_outputs,
-                found_inputs,
-            } => {
-                let mut unknown_spent_outpoints = vec![];
-                for outpoint in found_inputs {
-                    // this may confirm the same tx multiple times, but this shouldn't be a problem
-                    if !self.confirm_recorded_outgoing_transaction(*outpoint, *blkheight) {
-                        // if we're unable to confirm the spent outpoint, it means we don't know
-                        // the spending transaction because of a history desync. To keep the
-                        // history consistent we make a new 'unknown' spent output for these.
-                        unknown_spent_outpoints.push(*outpoint);
-                    }
-                }
+        let StateUpdate {
+            blkheight,
+            found_outputs,
+            found_inputs,
+            ..
+        } = update;
 
-                if !unknown_spent_outpoints.is_empty() {
-                    let unknown_sum = unknown_spent_outpoints
-                        .iter()
-                        .map(|outpoint| owned_outputs.get(outpoint).unwrap().amount)
-                        .sum();
+        let mut unknown_spent_outpoints = vec![];
+        for outpoint in found_inputs {
+            // this may confirm the same tx multiple times, but this shouldn't be a problem
+            if !self.confirm_recorded_outgoing_transaction(*outpoint, *blkheight) {
+                // if we're unable to confirm the spent outpoint, it means we don't know
+                // the spending transaction because of a history desync. To keep the
+                // history consistent we make a new 'unknown' spent output for these.
+                unknown_spent_outpoints.push(*outpoint);
+            }
+        }
 
-                    self.record_unknown_outgoing_transaction(
-                        unknown_spent_outpoints,
-                        unknown_sum,
-                        *blkheight,
-                    )?;
-                }
+        if !unknown_spent_outpoints.is_empty() {
+            let unknown_sum = unknown_spent_outpoints
+                .iter()
+                .map(|outpoint| owned_outputs.get(outpoint).unwrap().amount)
+                .sum();
 
-                // add new incoming transactions
-                let mut txs: HashMap<Txid, Amount> = HashMap::new();
-                for (outpoint, output) in found_outputs {
-                    // if this transaction is a send-to-self, it may have a change output present.
-                    // since we don't deduct change outputs from the sending side,
-                    // we shouldn't add the funds on the receiving side either.
-                    //
-                    // however, in case the user is recovering using a seed phrase,
-                    // we should NOT exclude the change output, since we don't have the sending
-                    // equivalent.
-                    //
-                    // since we're a label-less wallet, the only label we use is the change label,
-                    // so we simply check if an output is labelled.
-                    if output.label.is_some() {
-                        if self.check_is_self_send(outpoint.txid) {
-                            // if this is both a change output, as well as a tx we sent ourselves,
-                            // skip this output
-                            continue;
-                        }
-                    }
+            self.record_unknown_outgoing_transaction(
+                unknown_spent_outpoints,
+                unknown_sum,
+                *blkheight,
+            )?;
+        }
 
-                    let entry = txs.entry(outpoint.txid).or_default();
-                    *entry += output.value;
-                }
-                for (txid, amount) in txs {
-                    self.record_incoming_transaction(txid, amount, *blkheight);
+        // add new incoming transactions
+        let mut txs: HashMap<Txid, Amount> = HashMap::new();
+        for (outpoint, output) in found_outputs {
+            // if this transaction is a send-to-self, it may have a change output present.
+            // since we don't deduct change outputs from the sending side,
+            // we shouldn't add the funds on the receiving side either.
+            //
+            // however, in case the user is recovering using a seed phrase,
+            // we should NOT exclude the change output, since we don't have the sending
+            // equivalent.
+            //
+            // since we're a label-less wallet, the only label we use is the change label,
+            // so we simply check if an output is labelled.
+            if output.label.is_some() {
+                if self.check_is_self_send(outpoint.txid) {
+                    // if this is both a change output, as well as a tx we sent ourselves,
+                    // skip this output
+                    continue;
                 }
             }
-            StateUpdate::NoUpdate { .. } => (),
+
+            let entry = txs.entry(outpoint.txid).or_default();
+            *entry += output.value;
+        }
+        for (txid, amount) in txs {
+            self.record_incoming_transaction(txid, amount, *blkheight);
         }
 
         Ok(())

--- a/rust/src/api/outputs.rs
+++ b/rust/src/api/outputs.rs
@@ -77,37 +77,34 @@ impl OwnedOutputs {
 
     #[flutter_rust_bridge::frb(sync)]
     pub fn process_state_update(&mut self, update: &StateUpdate) -> Result<()> {
-        match update {
-            StateUpdate::Update {
-                blkheight,
-                blkhash,
-                found_outputs,
-                found_inputs,
-            } => {
-                // mark inputs as mined
-                for outpoint in found_inputs {
-                    // this may confirm the same tx multiple times, but this shouldn't be a problem
-                    self.mark_mined(*outpoint, *blkhash)?;
-                }
+        let StateUpdate {
+            blkheight,
+            blkhash,
+            found_outputs,
+            found_inputs,
+        } = update;
 
-                // record the outputs
-                self.0
-                    .extend(found_outputs.iter().map(|(outpoint, output)| {
-                        (
-                            *outpoint,
-                            OwnedOutput {
-                                blockheight: *blkheight,
-                                spend_status: OutputSpendStatus::Unspent,
-                                tweak: output.tweak.to_be_bytes(),
-                                amount: output.value,
-                                script: output.script_pubkey.clone(),
-                                label: output.label.clone(),
-                            },
-                        )
-                    }))
-            }
-            StateUpdate::NoUpdate { .. } => (),
+        // mark inputs as mined
+        for outpoint in found_inputs {
+            // this may confirm the same tx multiple times, but this shouldn't be a problem
+            self.mark_mined(*outpoint, *blkhash)?;
         }
+
+        // record the outputs
+        self.0
+            .extend(found_outputs.iter().map(|(outpoint, output)| {
+                (
+                    *outpoint,
+                    OwnedOutput {
+                        blockheight: *blkheight,
+                        spend_status: OutputSpendStatus::Unspent,
+                        tweak: output.tweak.to_be_bytes(),
+                        amount: output.value,
+                        script: output.script_pubkey.clone(),
+                        label: output.label.clone(),
+                    },
+                )
+            }));
 
         Ok(())
     }

--- a/rust/src/api/stream.rs
+++ b/rust/src/api/stream.rs
@@ -23,9 +23,6 @@ pub fn create_scan_result_stream(s: StreamSink<StateUpdate>) {
 impl StateUpdate {
     #[flutter_rust_bridge::frb(sync)]
     pub fn get_height(&self) -> u32 {
-        match self {
-            StateUpdate::Update { blkheight, .. } => blkheight.to_consensus_u32(),
-            StateUpdate::NoUpdate { blkheight } => blkheight.to_consensus_u32(),
-        }
+        self.blkheight.to_consensus_u32()
     }
 }

--- a/rust/src/api/wallet/scan.rs
+++ b/rust/src/api/wallet/scan.rs
@@ -34,7 +34,7 @@ impl SpWallet {
         let end = Height::from_consensus(to_height)?;
 
         let sp_client = self.client.clone();
-        let updater = StateUpdater::new();
+        let updater = StateUpdater::new(end);
 
         KEEP_SCANNING.store(true, std::sync::atomic::Ordering::Relaxed);
 

--- a/rust/src/state/updater.rs
+++ b/rust/src/state/updater.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    mem,
+    time::{Duration, Instant},
 };
 
 use spdk_wallet::updater::Updater;
@@ -13,99 +13,57 @@ use crate::stream::{send_scan_progress, send_state_update, StateUpdate};
 
 use anyhow::Result;
 
+const MAX_TIME_BETWEEN_UPDATES: Duration = Duration::from_secs(30);
+
 pub struct StateUpdater {
-    update: bool,
-    blkhash: Option<BlockHash>,
-    blkheight: Option<Height>,
-    found_outputs: HashMap<OutPoint, DiscoveredOutput>,
-    found_inputs: HashSet<OutPoint>,
+    last_update: Instant,
+    final_update_height: Height,
 }
 
 impl StateUpdater {
-    pub fn new() -> Self {
+    pub fn new(final_update_height: Height) -> Self {
         Self {
-            update: false,
-            blkheight: None,
-            blkhash: None,
-            found_outputs: HashMap::new(),
-            found_inputs: HashSet::new(),
-        }
-    }
-
-    pub fn to_update(&mut self) -> Result<StateUpdate> {
-        let blkheight = self
-            .blkheight
-            .ok_or(anyhow::Error::msg("blkheight not filled"))?;
-
-        if self.update {
-            self.update = false;
-
-            let blkhash = self.blkhash.ok_or(anyhow::Error::msg("blkhash not set"))?;
-
-            self.blkheight = None;
-            self.blkhash = None;
-
-            // take results, and insert new empty values
-            let found_inputs = mem::take(&mut self.found_inputs);
-            let found_outputs = mem::take(&mut self.found_outputs);
-
-            Ok(StateUpdate::Update {
-                blkheight,
-                blkhash,
-                found_outputs,
-                found_inputs,
-            })
-        } else {
-            Ok(StateUpdate::NoUpdate { blkheight })
+            last_update: Instant::now(),
+            final_update_height,
         }
     }
 }
 
 impl Updater for StateUpdater {
-    fn record_scan_progress(
-        &mut self,
-        _start: Height,
-        current: Height,
-        _end: Height,
-    ) -> Result<()> {
-        self.blkheight = Some(current);
-
-        send_scan_progress(current.to_consensus_u32());
-
-        Ok(())
-    }
-
-    fn record_block_outputs(
-        &mut self,
-        height: Height,
-        blkhash: BlockHash,
-        found_outputs: HashMap<OutPoint, DiscoveredOutput>,
-    ) -> Result<()> {
-        // may have already been written by record_block_inputs
-        self.update = true;
-        self.found_outputs = found_outputs;
-        self.blkhash = Some(blkhash);
-        self.blkheight = Some(height);
-
-        Ok(())
-    }
-
-    fn record_block_inputs(
+    fn record_block_scan_result(
         &mut self,
         blkheight: Height,
         blkhash: BlockHash,
-        found_inputs: HashSet<OutPoint>,
+        discovered_inputs: HashSet<OutPoint>,
+        discovered_outputs: HashMap<OutPoint, DiscoveredOutput>,
     ) -> Result<()> {
-        self.update = true;
-        self.blkheight = Some(blkheight);
-        self.blkhash = Some(blkhash);
-        self.found_inputs = found_inputs;
+        // we send a state update in 3 cases:
+        // - we have found new spent inputs or discovered outputs
+        // - the maximum delay between updates has been reached
+        // - we're sending the final update
+        let new_discoveries = !discovered_inputs.is_empty() || !discovered_outputs.is_empty();
+        let is_final_block_update = blkheight == self.final_update_height;
+        let max_delay_reached = self.last_update.elapsed() > MAX_TIME_BETWEEN_UPDATES;
 
-        Ok(())
-    }
+        if new_discoveries || is_final_block_update || max_delay_reached {
+            // sending a state update always implies we are writing to persistent storage
+            let update = StateUpdate {
+                blkheight,
+                blkhash,
+                found_outputs: discovered_outputs,
+                found_inputs: discovered_inputs,
+            };
 
-    fn save_to_persistent_storage(&mut self) -> Result<()> {
-        send_state_update(self.to_update()?);
+            send_state_update(update);
+
+            self.last_update = Instant::now();
+        }
+
+        // whether we update or not, we always notify the progress notifier
+        // note: the scan progress notifyer is purely to show scan progress to the user,
+        // it does not affect persistent storage
+        send_scan_progress(blkheight.to_consensus_u32());
+
         Ok(())
     }
 }

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -16,16 +16,11 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-pub enum StateUpdate {
-    NoUpdate {
-        blkheight: Height,
-    },
-    Update {
-        blkheight: Height,
-        blkhash: BlockHash,
-        found_outputs: HashMap<OutPoint, DiscoveredOutput>,
-        found_inputs: HashSet<OutPoint>,
-    },
+pub struct StateUpdate {
+    pub(crate) blkheight: Height,
+    pub(crate) blkhash: BlockHash,
+    pub(crate) found_outputs: HashMap<OutPoint, DiscoveredOutput>,
+    pub(crate) found_inputs: HashSet<OutPoint>,
 }
 
 pub fn create_scan_progress_stream(s: StreamSink<u32>) {


### PR DESCRIPTION
Simplify the updater trait so that it only reports scan results. Remove elements like deciding when the caller should write to persistent storage or not, as the caller should be responsible for this.