### PR TITLE
refactor(sync): rename scan -> sync in dart codebase

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,7 @@ import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +41,7 @@ void main() async {
   // Initialize contacts database
   await DatabaseHelper.instance.database;
   final walletState = await WalletState.create();
-  final scanNotifier = await ScanProgressNotifier.create();
+  final scanNotifier = await SyncProgressNotifier.create();
   final chainState = ChainState();
   final contactsState = ContactsState();
   final fiatExchangeRate = await FiatExchangeRateState.create();

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -14,7 +14,7 @@ import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
@@ -38,7 +38,7 @@ void main() async {
   // Initialize contacts database
   await DatabaseHelper.instance.database;
   final walletState = await WalletState.create();
-  final scanNotifier = await ScanProgressNotifier.create();
+  final scanNotifier = await SyncProgressNotifier.create();
   final chainState = ChainState();
   final contactsState = ContactsState();
   final fiatExchangeRate = await FiatExchangeRateState.create();

--- a/lib/repositories/wallet_repository.dart
+++ b/lib/repositories/wallet_repository.dart
@@ -20,7 +20,7 @@ const String _keyBirthday = "birthday";
 const String _keyNetwork = "network";
 const String _keyTxHistory = "txhistory";
 const String _keyOwnedOutputs = "ownedoutputs";
-const String _keyLastScan = "lastscan";
+const String _keyLastSync = "lastscan";
 const String _keyDanaAddress = "danaaddress";
 
 class WalletRepository {
@@ -41,7 +41,7 @@ class WalletRepository {
     await nonSecureStorage.clear(allowList: {
       _keyNetwork,
       _keyTxHistory,
-      _keyLastScan,
+      _keyLastSync,
       _keyOwnedOutputs,
       _keyBirthday,
       _keyDanaAddress,
@@ -49,7 +49,7 @@ class WalletRepository {
   }
 
   Future<SpWallet> setupWallet(WalletSetupResult walletSetup,
-      ApiNetwork network, DateTime? birthday, int? lastScan) async {
+      ApiNetwork network, DateTime? birthday, int? lastSync) async {
     if ((await secureStorage.readAll()).isNotEmpty) {
       throw Exception('Previous wallet not properly deleted');
     }
@@ -73,7 +73,7 @@ class WalletRepository {
     }
 
     // set default values for new wallet
-    await saveLastScan(lastScan);
+    await saveLastSync(lastSync);
     await saveHistory(TxHistory.empty());
     await saveOwnedOutputs(OwnedOutputs.empty());
 
@@ -146,17 +146,17 @@ class WalletRepository {
     return timestamp?.toDate();
   }
 
-  Future<void> saveLastScan(int? lastScan) async {
-    if (lastScan != null) {
-      await nonSecureStorage.setInt(_keyLastScan, lastScan);
+  Future<void> saveLastSync(int? lastSync) async {
+    if (lastSync != null) {
+      await nonSecureStorage.setInt(_keyLastSync, lastSync);
     } else {
-      await nonSecureStorage.remove(_keyLastScan);
+      await nonSecureStorage.remove(_keyLastSync);
     }
   }
 
-  Future<int?> readLastScan() async {
-    final lastScan = await nonSecureStorage.getInt(_keyLastScan);
-    return lastScan;
+  Future<int?> readLastSync() async {
+    final lastSync = await nonSecureStorage.getInt(_keyLastSync);
+    return lastSync;
   }
 
   Future<void> saveOwnedOutputs(OwnedOutputs ownedOutputs) async {
@@ -192,13 +192,13 @@ class WalletRepository {
     final history = await readHistory();
     final outputs = await readOwnedOutputs();
     final seedPhrase = await readSeedPhrase();
-    final lastScan = await readLastScan();
+    final lastSync = await readLastSync();
     final network = await readNetwork();
 
     return WalletBackup(
         wallet: wallet!,
         birthday: birthday?.toSeconds(),
-        lastScan: lastScan!,
+        lastScan: lastSync!,
         txHistory: history,
         ownedOutputs: outputs,
         seedPhrase: seedPhrase,
@@ -224,6 +224,6 @@ class WalletRepository {
 
     await saveHistory(backup.txHistory);
     await saveOwnedOutputs(backup.ownedOutputs);
-    await saveLastScan(backup.lastScan);
+    await saveLastSync(backup.lastScan);
   }
 }

--- a/lib/screens/onboarding/overview.dart
+++ b/lib/screens/onboarding/overview.dart
@@ -13,7 +13,7 @@ import 'package:danawallet/screens/onboarding/recovery/seed_phrase.dart';
 import 'package:danawallet/services/backup_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button_outlined.dart';
@@ -37,7 +37,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
       final chainState = Provider.of<ChainState>(context, listen: false);
       final contactsState = Provider.of<ContactsState>(context, listen: false);
       final scanProgress =
-          Provider.of<ScanProgressNotifier>(context, listen: false);
+          Provider.of<SyncProgressNotifier>(context, listen: false);
       final encryptedBackup = await BackupService.getEncryptedBackupFromFile();
 
       if (encryptedBackup != null) {
@@ -112,7 +112,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
     final chainState = Provider.of<ChainState>(context, listen: false);
     final contactsState = Provider.of<ContactsState>(context, listen: false);
     final scanProgress =
-        Provider.of<ScanProgressNotifier>(context, listen: false);
+        Provider.of<SyncProgressNotifier>(context, listen: false);
 
     final blindbitUrl = network.defaultBlindbitUrl;
 

--- a/lib/screens/onboarding/recovery/seed_phrase.dart
+++ b/lib/screens/onboarding/recovery/seed_phrase.dart
@@ -8,7 +8,7 @@ import 'package:danawallet/screens/onboarding/recovery/birthday_picker_screen.da
 import 'package:danawallet/screens/onboarding/register_dana_address.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/loading_widget.dart';
@@ -51,7 +51,7 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
       final chainState = Provider.of<ChainState>(context, listen: false);
       final contactsState = Provider.of<ContactsState>(context, listen: false);
       final scanProgress =
-          Provider.of<ScanProgressNotifier>(context, listen: false);
+          Provider.of<SyncProgressNotifier>(context, listen: false);
 
       // Get birthday: navigate to picker if user knows it, else null
       DateTime? birthday;

--- a/lib/screens/settings/network/network_settings_screen.dart
+++ b/lib/screens/settings/network/network_settings_screen.dart
@@ -24,9 +24,9 @@ class NetworkSettingsScreen extends StatelessWidget {
       if (isDevEnv)
         _NetworkSettingsItem(
           icon: Icons.schedule,
-          title: 'Set scan height',
-          subtitle: 'Reset blockchain scan position',
-          onTap: () => _onSetLastScan(context),
+          title: 'Set sync height',
+          subtitle: 'Reset blockchain sync position',
+          onTap: () => _onSetLastSync(context),
         ),
       if (isDevEnv)
         _NetworkSettingsItem(
@@ -38,26 +38,26 @@ class NetworkSettingsScreen extends StatelessWidget {
     ];
   }
 
-  Future<void> _onSetLastScan(BuildContext context) async {
+  Future<void> _onSetLastSync(BuildContext context) async {
     final walletState = Provider.of<WalletState>(context, listen: false);
     final homeState = Provider.of<HomeState>(context, listen: false);
     final chainState = Provider.of<ChainState>(context, listen: false);
 
     TextEditingController controller = TextEditingController();
-    final scanHeight = await showInputAlertDialog(
+    final syncHeight = await showInputAlertDialog(
         controller,
         TextInputType.number,
-        'Enter scan height',
-        'Enter current scan height (numeric value)');
-    if (scanHeight is int) {
-      await walletState.resetToScanHeight(scanHeight);
+        'Enter sync height',
+        'Enter current sync height (numeric value)');
+    if (syncHeight is int) {
+      await walletState.resetToSyncHeight(syncHeight);
       chainState.clearSyncHistory();
       homeState.showMainScreen();
-    } else if (scanHeight is bool && scanHeight) {
+    } else if (syncHeight is bool && syncHeight) {
       final birthday = walletState.birthday;
       // TODO probably better and simpler to set lastScan to null and let the synchronization service set it to the birthday height
       final height = await chainState.getBlockHeightFromDate(birthday!);
-      await walletState.resetToScanHeight(height);
+      await walletState.resetToSyncHeight(height);
       chainState.clearSyncHistory();
       homeState.showMainScreen();
     }

--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -9,7 +9,7 @@ import 'package:danawallet/services/backup_service.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/states/home_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -46,12 +46,12 @@ class WalletSettingsScreen extends StatelessWidget {
   Future<void> _onRemoveWallet(
     WalletState walletState,
     ChainState chainState,
-    ScanProgressNotifier scanProgress,
+    SyncProgressNotifier scanProgress,
     HomeState homeState,
     ContactsState contacts,
   ) async {
     try {
-      await scanProgress.interruptScan();
+      await scanProgress.interruptSync();
       chainState.reset();
       await walletState.reset();
       await SettingsRepository.instance.resetAll();
@@ -87,7 +87,7 @@ class WalletSettingsScreen extends StatelessWidget {
       final homeState = Provider.of<HomeState>(context, listen: false);
       final chainState = Provider.of<ChainState>(context, listen: false);
       final scanProgress =
-          Provider.of<ScanProgressNotifier>(context, listen: false);
+          Provider.of<SyncProgressNotifier>(context, listen: false);
       final contacts = Provider.of<ContactsState>(context, listen: false);
 
       await _onRemoveWallet(

--- a/lib/screens/spend/amount_selection.dart
+++ b/lib/screens/spend/amount_selection.dart
@@ -75,8 +75,8 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
 
     final availableBalance = walletState.amount;
     int blocksToScan = 0;
-    if (walletState.lastScan != null) {
-      blocksToScan = chainState.tip - walletState.lastScan!;
+    if (walletState.lastSync != null) {
+      blocksToScan = chainState.tip - walletState.lastSync!;
     }
 
     String recipientName = form.recipient!.displayName;

--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -12,7 +12,7 @@ import 'package:danawallet/screens/spend/choose_recipient.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/contacts_state.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -471,7 +471,7 @@ class WalletScreenState extends State<WalletScreen> {
   }
 
   Widget buildFundingScreen(String silentPaymentAddress, String? danaAddress,
-      ScanProgressNotifier scanProgress, ChainState chainState) {
+      SyncProgressNotifier scanProgress, ChainState chainState) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20.0),
       child: Column(
@@ -578,7 +578,7 @@ class WalletScreenState extends State<WalletScreen> {
   Widget build(BuildContext context) {
     final walletState = Provider.of<WalletState>(context);
     final exchangeRate = Provider.of<FiatExchangeRateState>(context);
-    final scanProgress = Provider.of<ScanProgressNotifier>(context);
+    final scanProgress = Provider.of<SyncProgressNotifier>(context);
     final chainState = Provider.of<ChainState>(context);
     final danaAddress = walletState.danaAddress;
 

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/states/chain_state.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:logger/logger.dart';
@@ -11,7 +11,7 @@ import 'package:logger/logger.dart';
 class SynchronizationService {
   WalletState walletState;
   ChainState chainState;
-  ScanProgressNotifier scanProgress;
+  SyncProgressNotifier scanProgress;
 
   // first sync will set the start height, all other syncs will keep the same height
   // this is useful if we receive an error while syncing, and restart the sync process.
@@ -89,41 +89,41 @@ class SynchronizationService {
   }
 
   Future<void> _performSynchronizationTask() async {
-    if (walletState.lastScan == null) {
-      // if we just recovered a wallet, we haven't set the lastScan variable yet.
-      Logger().d("Setting last scan to block height of birthday");
+    if (walletState.lastSync == null) {
+      // if we just recovered a wallet, we haven't set the lastSync variable yet.
+      Logger().d("Setting last sync to block height of birthday");
       try {
-        await _initializeLastScan();
+        await _initializeLastSync();
       } catch (e) {
         Logger().e("Error initializing last scan: $e");
         return;
       }
     }
 
-    if (walletState.lastScan! < chainState.tip) {
+    if (walletState.lastSync! < chainState.tip) {
       if (!scanProgress.isScanning) {
         Logger().i("Starting sync");
 
         // set start height if not yet set
-        _startHeight ??= walletState.lastScan!;
+        _startHeight ??= walletState.lastSync!;
 
         await scanProgress.scan(walletState, _startHeight!, chainState.tip);
       }
     }
 
-    if (chainState.tip < walletState.lastScan!) {
+    if (chainState.tip < walletState.lastSync!) {
       // not sure what we should do here, that's really bad
       Logger().e('Current height is less than wallet last scan');
     }
   }
 
-  Future<void> _initializeLastScan() async {
+  Future<void> _initializeLastSync() async {
     // if wallet birthday isn't known, use the default birthday timestamp
     final timestamp = walletState.birthday ?? defaultBirthday;
 
     final blockHeight = await chainState.getBlockHeightFromDate(timestamp);
 
-    walletState.lastScan = blockHeight;
+    walletState.lastSync = blockHeight;
   }
 
   void stopSyncTimer() {

--- a/lib/states/chain_state.dart
+++ b/lib/states/chain_state.dart
@@ -5,7 +5,7 @@ import 'package:danawallet/generated/rust/api/chain.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
 import 'package:danawallet/services/synchronization_service.dart';
-import 'package:danawallet/states/scan_progress_notifier.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
@@ -37,7 +37,7 @@ class ChainState extends ChangeNotifier {
   }
 
   void startSyncService(WalletState walletState,
-      ScanProgressNotifier scanProgress, bool immediate) {
+      SyncProgressNotifier scanProgress, bool immediate) {
     // start sync service & timer
     _synchronizationService = SynchronizationService(
         chainState: this, walletState: walletState, scanProgress: scanProgress);

--- a/lib/states/sync_progress_notifier.dart
+++ b/lib/states/sync_progress_notifier.dart
@@ -8,21 +8,21 @@ import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 
-class ScanProgressNotifier extends ChangeNotifier {
+class SyncProgressNotifier extends ChangeNotifier {
   Completer? _completer;
   double? progress;
   late int startHeight;
   late int endHeight;
 
-  late StreamSubscription scanProgressSubscription;
+  late StreamSubscription syncProgressSubscription;
 
   bool get isScanning => _completer != null && !_completer!.isCompleted;
 
   // private constructor
-  ScanProgressNotifier._();
+  SyncProgressNotifier._();
 
   Future<void> _initialize() async {
-    scanProgressSubscription = createScanProgressStream().listen(((current) {
+    syncProgressSubscription = createSyncProgressStream().listen(((current) {
       double scanned = (current - startHeight).toDouble();
       double total = (endHeight - startHeight).toDouble();
       double progress = scanned / total;
@@ -34,15 +34,15 @@ class ScanProgressNotifier extends ChangeNotifier {
     }));
   }
 
-  static Future<ScanProgressNotifier> create() async {
-    final instance = ScanProgressNotifier._();
+  static Future<SyncProgressNotifier> create() async {
+    final instance = SyncProgressNotifier._();
     await instance._initialize();
     return instance;
   }
 
   @override
   void dispose() {
-    scanProgressSubscription.cancel();
+    syncProgressSubscription.cancel();
     super.dispose();
   }
 
@@ -65,7 +65,7 @@ class ScanProgressNotifier extends ChangeNotifier {
 
     // start syncing from the first block after our last sync
     // we ignore the startHeight here, because we may be continuing from another sync
-    final fromHeight = walletState.lastScan! + 1;
+    final fromHeight = walletState.lastSync! + 1;
     final toHeight = chainTip;
 
     try {
@@ -75,7 +75,7 @@ class ScanProgressNotifier extends ChangeNotifier {
           walletState.network.defaultBlindbitUrl;
       final dustLimit = await settings.getDustLimit() ?? defaultDustLimit;
 
-      if (walletState.lastScan == null) {
+      if (walletState.lastSync == null) {
         throw Exception("Last scan is null");
       }
 
@@ -97,9 +97,9 @@ class ScanProgressNotifier extends ChangeNotifier {
     deactivate();
   }
 
-  Future<void> interruptScan() async {
+  Future<void> interruptSync() async {
     if (isScanning) {
-      SpWallet.interruptScanning();
+      SpWallet.interruptSync();
 
       // this makes sure the scan function has been terminated
       await _completer?.future;

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -33,7 +33,7 @@ class WalletState extends ChangeNotifier {
   // variables that change
   late ApiAmount amount;
   late ApiAmount unconfirmedChange;
-  late int? lastScan;
+  late int? lastSync;
   late TxHistory txHistory;
   late OwnedOutputs ownedOutputs;
 
@@ -41,7 +41,7 @@ class WalletState extends ChangeNotifier {
   Bip353Address? danaAddress;
 
   // stream to receive updates while scanning
-  late StreamSubscription scanResultSubscription;
+  late StreamSubscription syncResultSubscription;
 
   // private constructor
   WalletState._();
@@ -53,16 +53,16 @@ class WalletState extends ChangeNotifier {
   }
 
   Future<void> _initStreams() async {
-    scanResultSubscription = createScanResultStream().listen(((event) async {
+    syncResultSubscription = createSyncResultStream().listen(((event) async {
       // process update
-      lastScan = event.getHeight();
+      lastSync = event.getHeight();
       txHistory.processStateUpdate(update: event, ownedOutputs: ownedOutputs);
       ownedOutputs.processStateUpdate(update: event);
 
       // save updates to storage
       await walletRepository.saveHistory(txHistory);
       await walletRepository.saveOwnedOutputs(ownedOutputs);
-      await walletRepository.saveLastScan(lastScan);
+      await walletRepository.saveLastSync(lastSync);
 
       // update UI
       await _updateWalletState();
@@ -95,7 +95,7 @@ class WalletState extends ChangeNotifier {
 
   @override
   void dispose() {
-    scanResultSubscription.cancel();
+    syncResultSubscription.cancel();
     super.dispose();
   }
 
@@ -118,8 +118,8 @@ class WalletState extends ChangeNotifier {
     this.birthday = birthday;
     this.network = network;
 
-    // lastScan will be initialized by chainState synchronization service
-    lastScan = null;
+    // lastSync will be initialized by chainState synchronization service
+    lastSync = null;
 
     await _updateWalletState();
   }
@@ -138,7 +138,7 @@ class WalletState extends ChangeNotifier {
     changePaymentCode = wallet.getChangeAddress();
     birthday = now;
     this.network = network;
-    lastScan = currentTip;
+    lastSync = currentTip;
     await _updateWalletState();
   }
 
@@ -188,13 +188,13 @@ class WalletState extends ChangeNotifier {
     }
   }
 
-  Future<void> resetToScanHeight(int height) async {
-    lastScan = height;
+  Future<void> resetToSyncHeight(int height) async {
+    lastSync = height;
 
     ownedOutputs.resetToHeight(height: height);
     txHistory.resetToHeight(height: height);
 
-    await walletRepository.saveLastScan(height);
+    await walletRepository.saveLastSync(height);
     await walletRepository.saveHistory(txHistory);
     await walletRepository.saveOwnedOutputs(ownedOutputs);
 
@@ -205,7 +205,7 @@ class WalletState extends ChangeNotifier {
   Future<void> _updateWalletState() async {
     txHistory = await walletRepository.readHistory();
     ownedOutputs = await walletRepository.readOwnedOutputs();
-    lastScan = await walletRepository.readLastScan();
+    lastSync = await walletRepository.readLastSync();
 
     amount = ownedOutputs.getUnspentAmount();
     unconfirmedChange = txHistory.getUnconfirmedChange();

--- a/rust/src/api/stream.rs
+++ b/rust/src/api/stream.rs
@@ -11,13 +11,13 @@ pub fn create_log_stream(s: StreamSink<LogEntry>, level: LogLevel, log_dependenc
 }
 
 #[flutter_rust_bridge::frb(sync)]
-pub fn create_scan_progress_stream(s: StreamSink<u32>) {
-    stream::create_scan_progress_stream(s);
+pub fn create_sync_progress_stream(s: StreamSink<u32>) {
+    stream::create_sync_progress_stream(s);
 }
 
 #[flutter_rust_bridge::frb(sync)]
-pub fn create_scan_result_stream(s: StreamSink<StateUpdate>) {
-    stream::create_scan_update_stream(s);
+pub fn create_sync_result_stream(s: StreamSink<StateUpdate>) {
+    stream::create_sync_update_stream(s);
 }
 
 impl StateUpdate {

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,5 +1,5 @@
 mod info;
-mod scan;
+mod sync;
 pub mod setup;
 mod transaction;
 

--- a/rust/src/api/wallet/sync.rs
+++ b/rust/src/api/wallet/sync.rs
@@ -4,7 +4,7 @@ use spdk_wallet::bitcoin::absolute::Height;
 use spdk_wallet::bitcoin::Amount;
 use spdk_wallet::scanner::SpScanner;
 
-use crate::{api::outputs::OwnedOutPoints, state::StateUpdater, wallet::KEEP_SCANNING};
+use crate::{api::outputs::OwnedOutPoints, state::StateUpdater, wallet::KEEP_SYNCING};
 
 use super::SpWallet;
 
@@ -13,8 +13,8 @@ const ENABLE_CUTTHROUGH: bool = true;
 
 impl SpWallet {
     #[flutter_rust_bridge::frb(sync)]
-    pub fn interrupt_scanning() {
-        KEEP_SCANNING.store(false, std::sync::atomic::Ordering::Relaxed);
+    pub fn interrupt_sync() {
+        KEEP_SYNCING.store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub async fn sync_to_height(
@@ -36,14 +36,14 @@ impl SpWallet {
         let sp_client = self.client.clone();
         let updater = StateUpdater::new(end);
 
-        KEEP_SCANNING.store(true, std::sync::atomic::Ordering::Relaxed);
+        KEEP_SYNCING.store(true, std::sync::atomic::Ordering::Relaxed);
 
         let mut scanner = SpScanner::new(
             sp_client,
             Box::new(updater),
             Box::new(backend),
             owned_outpoints.to_inner(),
-            &KEEP_SCANNING,
+            &KEEP_SYNCING,
         );
 
         scanner

--- a/rust/src/state/updater.rs
+++ b/rust/src/state/updater.rs
@@ -9,7 +9,7 @@ use spdk_wallet::{
     updater::DiscoveredOutput,
 };
 
-use crate::stream::{send_scan_progress, send_state_update, StateUpdate};
+use crate::stream::{send_sync_progress, send_sync_update, StateUpdate};
 
 use anyhow::Result;
 
@@ -54,7 +54,7 @@ impl Updater for StateUpdater {
                 found_inputs: discovered_inputs,
             };
 
-            send_state_update(update);
+            send_sync_update(update);
 
             self.last_update = Instant::now();
         }
@@ -62,7 +62,7 @@ impl Updater for StateUpdater {
         // whether we update or not, we always notify the progress notifier
         // note: the scan progress notifyer is purely to show scan progress to the user,
         // it does not affect persistent storage
-        send_scan_progress(blkheight.to_consensus_u32());
+        send_sync_progress(blkheight.to_consensus_u32());
 
         Ok(())
     }

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -23,24 +23,24 @@ pub struct StateUpdate {
     pub(crate) found_inputs: HashSet<OutPoint>,
 }
 
-pub fn create_scan_progress_stream(s: StreamSink<u32>) {
+pub fn create_sync_progress_stream(s: StreamSink<u32>) {
     let mut stream_sink = SCAN_PROGRESS_STREAM_SINK.lock().unwrap();
     *stream_sink = Some(s);
 }
 
-pub fn create_scan_update_stream(s: StreamSink<StateUpdate>) {
+pub fn create_sync_update_stream(s: StreamSink<StateUpdate>) {
     let mut stream_sink = STATE_UPDATE_STREAM_SINK.lock().unwrap();
     *stream_sink = Some(s);
 }
 
-pub(crate) fn send_scan_progress(scan_progress: u32) {
+pub(crate) fn send_sync_progress(scan_progress: u32) {
     let stream_sink = SCAN_PROGRESS_STREAM_SINK.lock().unwrap();
     if let Some(stream_sink) = stream_sink.as_ref() {
         stream_sink.add(scan_progress).unwrap();
     }
 }
 
-pub(crate) fn send_state_update(update: StateUpdate) {
+pub(crate) fn send_sync_update(update: StateUpdate) {
     let stream_sink = STATE_UPDATE_STREAM_SINK.lock().unwrap();
     if let Some(stream_sink) = stream_sink.as_ref() {
         stream_sink.add(update).unwrap();

--- a/rust/src/wallet.rs
+++ b/rust/src/wallet.rs
@@ -9,7 +9,7 @@ use spdk_wallet::bitcoin::secp256k1::SecretKey;
 use spdk_wallet::bitcoin::{Network, NetworkKind};
 
 lazy_static! {
-    pub static ref KEEP_SCANNING: AtomicBool = AtomicBool::new(true);
+    pub static ref KEEP_SYNCING: AtomicBool = AtomicBool::new(true);
 }
 
 pub type WalletFingerprint = [u8; 8];


### PR DESCRIPTION
As we discussed a while back, we should use the term 'syncing' when talking about scanning the blockchain for new transactions.