### PR TITLE
feat: reset wallet to birthday

### DIFF
--- a/lib/screens/settings/network/network_settings_screen.dart
+++ b/lib/screens/settings/network/network_settings_screen.dart
@@ -54,10 +54,8 @@ class NetworkSettingsScreen extends StatelessWidget {
       chainState.clearSyncHistory();
       homeState.showMainScreen();
     } else if (syncHeight is bool && syncHeight) {
-      final birthday = walletState.birthday;
-      // TODO probably better and simpler to set lastScan to null and let the synchronization service set it to the birthday height
-      final height = await chainState.getBlockHeightFromDate(birthday!);
-      await walletState.resetToSyncHeight(height);
+      // if no height is provided, we reset to the birthday
+      await walletState.resetToBirthday();
       chainState.clearSyncHistory();
       homeState.showMainScreen();
     }

--- a/lib/screens/settings/personalization/personalisation_settings_screen.dart
+++ b/lib/screens/settings/personalization/personalisation_settings_screen.dart
@@ -6,7 +6,6 @@ import 'package:danawallet/screens/settings/personalization/change_fiat_screen.d
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
 import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/states/fiat_exchange_rate_state.dart';
-import 'package:danawallet/states/home_state.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -33,6 +33,12 @@ class WalletSettingsScreen extends StatelessWidget {
           onTap: () => _onBackupWalletButtonPressed(),
         ),
       _WalletSettingsItem(
+        icon: Icons.restore,
+        title: 'Reset wallet data',
+        subtitle: 'Reset wallet data to its birthday',
+        onTap: () => _onResetToBirthdayButtonPressed(context),
+      ),
+      _WalletSettingsItem(
         icon: Icons.delete_outline,
         title: 'Wipe wallet',
         subtitle: 'Delete wallet and all data',
@@ -78,6 +84,31 @@ class WalletSettingsScreen extends StatelessWidget {
     }
   }
 
+  Future<void> _onResetToBirthdayButtonPressed(BuildContext context) async {
+    final confirmed = await showConfirmationAlertDialog(
+        'Confirm resetting wallet data',
+        "Are you sure you want to reset your wallet data? Only do this if you think your wallet data is corrupted, as you will lose valuable data like transaction history.");
+
+    if (confirmed && context.mounted) {
+      final walletState = Provider.of<WalletState>(context, listen: false);
+      final chainState = Provider.of<ChainState>(context, listen: false);
+      final scanProgress =
+          Provider.of<SyncProgressNotifier>(context, listen: false);
+
+      // first interrupt the sync process if this is still running
+      await scanProgress.interruptSync();
+
+      // clear cached start height from sync history
+      chainState.clearSyncHistory();
+
+      // reset wallet data
+      await walletState.resetToBirthday();
+
+      // go to home screen after resetting
+      if (context.mounted) goToHomeScreen(context);
+    }
+  }
+
   Future<void> _onWipeWalletButtonPressed(BuildContext context) async {
     final confirmed = await showConfirmationAlertDialog('Confirm deletion',
         "Are you sure you want to wipe your wallet? Without a backup, you will lose your funds!");
@@ -107,7 +138,8 @@ class WalletSettingsScreen extends StatelessWidget {
 
     if (context.mounted) {
       if (mnemonic != null) {
-        goToScreen(context, ViewMnemonicScreen(mnemonic: mnemonic, birthday: wallet.birthday));
+        goToScreen(context,
+            ViewMnemonicScreen(mnemonic: mnemonic, birthday: wallet.birthday));
       } else {
         showAlertDialog("Seed phrase unknown",
             "Seed phrase unknown! Did you import from keys?");

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -188,9 +188,20 @@ class WalletState extends ChangeNotifier {
     }
   }
 
-  Future<void> resetToSyncHeight(int height) async {
-    lastSync = height;
+  Future<void> resetToBirthday() async {
+    // when we reset to the birthday, clear out all stored data
+    await walletRepository.saveHistory(TxHistory.empty());
+    await walletRepository.saveOwnedOutputs(OwnedOutputs.empty());
 
+    // the sync service will handle setting the lastSync to the birthday height
+    await walletRepository.saveLastSync(null);
+
+    await _updateWalletState();
+    notifyListeners();
+  }
+
+  Future<void> resetToSyncHeight(int height) async {
+    // note: this feature is not stable, as it does not take output spent status into account
     ownedOutputs.resetToHeight(height: height);
     txHistory.resetToHeight(height: height);
 


### PR DESCRIPTION
Add an option to the wallet settings that allows users to reset their wallet data to the birthday. This wipes all local transaction data and the sync height, but it does not wipe the seed phrase.

Note: this currently uses an ugly confirmation popup, just like the 'wipe wallet' button. This should be replaced soon.