### PR TITLE
refactor: drop spwallet serialize/deserialize

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "backend-blindbit-v1"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b8cd06ecb9c2688632eef52842d7ac26a88608eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1960,7 +1960,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "silentpayments"
 version = "0.5.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b8cd06ecb9c2688632eef52842d7ac26a88608eb"
 dependencies = [
  "bech32 0.9.1",
  "bimap",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "spdk-core"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b8cd06ecb9c2688632eef52842d7ac26a88608eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "spdk-wallet"
 version = "0.1.0"
-source = "git+https://github.com/cygnet3/spdk?branch=master#317c0dd464fc7977b2812c9f26266f547ac0c2a1"
+source = "git+https://github.com/cygnet3/spdk?branch=master#b8cd06ecb9c2688632eef52842d7ac26a88608eb"
 dependencies = [
  "anyhow",
  "backend-blindbit-v1",

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use spdk_wallet::bitcoin::secp256k1::SecretKey;
 use spdk_wallet::client::{SpClient, SpendKey};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[frb(opaque)]
 pub struct SpWallet {
     client: SpClient,
@@ -28,16 +28,6 @@ impl SpWallet {
             client,
             wallet_fingerprint,
         })
-    }
-
-    #[frb(sync)]
-    pub fn decode(encoded_wallet: String) -> Result<Self> {
-        Ok(serde_json::from_str(&encoded_wallet)?)
-    }
-
-    #[frb(sync)]
-    pub fn encode(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self)?)
     }
 
     #[frb(sync)]


### PR DESCRIPTION
These are a remnant of when we used to store the serialized SpWallet struct directly in flutter secure storage.