### PR TITLE
feat: add confirm screens for wallet deletion and reset

### DIFF
--- a/lib/screens/settings/wallet/confirm_reset_wallet.dart
+++ b/lib/screens/settings/wallet/confirm_reset_wallet.dart
@@ -1,0 +1,88 @@
+import 'package:bitcoin_ui/bitcoin_ui.dart';
+import 'package:danawallet/global_functions.dart';
+import 'package:danawallet/states/chain_state.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
+import 'package:danawallet/states/wallet_state.dart';
+import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
+import 'package:danawallet/widgets/icons/circular_icon.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+const IconData pageIcon = Icons.warning_amber_rounded;
+const Color pageColor = Colors.orange;
+
+const String titleText = "Reset wallet to birthday";
+const String infoText =
+    "Are you sure you want to reset your wallet data? Only do this if you think your wallet data is corrupted, as you will lose valuable data like transaction history. This action cannot be undone.";
+const String buttonText = "Reset wallet data";
+
+class ConfirmWalletResetScreen extends StatelessWidget {
+  const ConfirmWalletResetScreen({super.key});
+
+  Future<void> onConfirmResetWallet(BuildContext context) async {
+    final walletState = Provider.of<WalletState>(context, listen: false);
+    final chainState = Provider.of<ChainState>(context, listen: false);
+    final scanProgress =
+        Provider.of<SyncProgressNotifier>(context, listen: false);
+
+    // first interrupt the sync process if this is still running
+    await scanProgress.interruptSync();
+
+    // clear cached start height from sync history
+    chainState.clearSyncHistory();
+
+    // reset wallet data
+    await walletState.resetToBirthday();
+
+    // go to home screen after resetting
+    if (context.mounted) goToHomeScreen(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const icon = CircularIcon(
+        icon: Icon(
+          pageIcon,
+          color: Colors.white,
+          size: 25,
+        ),
+        radius: 25,
+        color: pageColor);
+
+    final header = Text(
+      titleText,
+      style: BitcoinTextStyle.title3(Bitcoin.black),
+    );
+
+    final text = Text(
+      infoText,
+      style: BitcoinTextStyle.body3(Bitcoin.neutral8),
+    );
+    final items = Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        icon,
+        header,
+        text,
+      ],
+    );
+
+    final body = Column(children: [
+      Expanded(child: items),
+      const Spacer(),
+    ]);
+
+    final footer = FooterButton(
+      title: buttonText,
+      onPressed: () => onConfirmResetWallet(context),
+      color: pageColor,
+    );
+
+    return ScreenSkeleton(
+      body: body,
+      showBackButton: true,
+      footer: footer,
+    );
+  }
+}

--- a/lib/screens/settings/wallet/confirm_wallet_deletion.dart
+++ b/lib/screens/settings/wallet/confirm_wallet_deletion.dart
@@ -1,0 +1,100 @@
+import 'package:bitcoin_ui/bitcoin_ui.dart';
+import 'package:danawallet/repositories/settings_repository.dart';
+import 'package:danawallet/screens/onboarding/introduction.dart';
+import 'package:danawallet/states/chain_state.dart';
+import 'package:danawallet/states/contacts_state.dart';
+import 'package:danawallet/states/home_state.dart';
+import 'package:danawallet/states/sync_progress_notifier.dart';
+import 'package:danawallet/states/wallet_state.dart';
+import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
+import 'package:danawallet/widgets/icons/circular_icon.dart';
+import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+const Color pageColor = Colors.redAccent;
+
+const String titleText = "Wipe wallet from this device";
+const String info1Text =
+    "This cannot be undone. Your recovery phrase and all other wallet data will be erased from this device.";
+const String info2Text =
+    "Please make sure you have backed up your seed phrase beforehand!";
+const String buttonText = "Wipe wallet";
+
+class ConfirmWalletDeletionScreen extends StatelessWidget {
+  const ConfirmWalletDeletionScreen({super.key});
+
+  Future<void> onConfirmWipeWallet(BuildContext context) async {
+    final walletState = Provider.of<WalletState>(context, listen: false);
+    final homeState = Provider.of<HomeState>(context, listen: false);
+    final chainState = Provider.of<ChainState>(context, listen: false);
+    final scanProgress =
+        Provider.of<SyncProgressNotifier>(context, listen: false);
+    final contacts = Provider.of<ContactsState>(context, listen: false);
+
+    await scanProgress.interruptSync();
+    chainState.reset();
+    await walletState.reset();
+    await SettingsRepository.instance.resetAll();
+    contacts.reset();
+    homeState.reset();
+
+    if (context.mounted) {
+      Navigator.pushReplacement(context,
+          MaterialPageRoute(builder: (context) => const IntroductionScreen()));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const icon = CircularIcon(
+        icon: Icon(
+          Icons.close,
+          color: Colors.white,
+          size: 20,
+        ),
+        radius: 25,
+        color: pageColor);
+
+    final header = Text(
+      titleText,
+      style: BitcoinTextStyle.title3(Bitcoin.black),
+    );
+
+    final text1 = Text(
+      info1Text,
+      style: BitcoinTextStyle.body3(Bitcoin.neutral8),
+    );
+
+    final text2 = Text(
+      info2Text,
+      style: BitcoinTextStyle.body3(Bitcoin.neutral8),
+    );
+    final items = Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        icon,
+        header,
+        text1,
+        text2,
+      ],
+    );
+
+    final body = Column(children: [
+      Expanded(child: items),
+      const Spacer(),
+    ]);
+
+    final footer = FooterButton(
+      title: buttonText,
+      onPressed: () => onConfirmWipeWallet(context),
+      color: pageColor,
+    );
+
+    return ScreenSkeleton(
+      body: body,
+      showBackButton: true,
+      footer: footer,
+    );
+  }
+}

--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -1,14 +1,11 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
-import 'package:danawallet/repositories/settings_repository.dart';
-import 'package:danawallet/screens/onboarding/introduction.dart';
 import 'package:danawallet/screens/recovery/view_mnemonic_screen.dart';
+import 'package:danawallet/screens/settings/wallet/confirm_wallet_deletion.dart';
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
 import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/services/backup_service.dart';
 import 'package:danawallet/states/chain_state.dart';
-import 'package:danawallet/states/contacts_state.dart';
-import 'package:danawallet/states/home_state.dart';
 import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
@@ -46,26 +43,6 @@ class WalletSettingsScreen extends StatelessWidget {
         isDestructive: true,
       ),
     ];
-  }
-
-  // Business logic methods
-  Future<void> _onRemoveWallet(
-    WalletState walletState,
-    ChainState chainState,
-    SyncProgressNotifier scanProgress,
-    HomeState homeState,
-    ContactsState contacts,
-  ) async {
-    try {
-      await scanProgress.interruptSync();
-      chainState.reset();
-      await walletState.reset();
-      await SettingsRepository.instance.resetAll();
-      contacts.reset();
-      homeState.reset();
-    } catch (e) {
-      rethrow;
-    }
   }
 
   Future<void> _onBackupWalletButtonPressed() async {
@@ -109,27 +86,8 @@ class WalletSettingsScreen extends StatelessWidget {
     }
   }
 
-  Future<void> _onWipeWalletButtonPressed(BuildContext context) async {
-    final confirmed = await showConfirmationAlertDialog('Confirm deletion',
-        "Are you sure you want to wipe your wallet? Without a backup, you will lose your funds!");
-
-    if (confirmed && context.mounted) {
-      final walletState = Provider.of<WalletState>(context, listen: false);
-      final homeState = Provider.of<HomeState>(context, listen: false);
-      final chainState = Provider.of<ChainState>(context, listen: false);
-      final scanProgress =
-          Provider.of<SyncProgressNotifier>(context, listen: false);
-      final contacts = Provider.of<ContactsState>(context, listen: false);
-
-      await _onRemoveWallet(
-          walletState, chainState, scanProgress, homeState, contacts);
-      if (context.mounted) {
-        Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-                builder: (context) => const IntroductionScreen()));
-      }
-    }
+  void _onWipeWalletButtonPressed(BuildContext context) {
+    goToScreen(context, const ConfirmWalletDeletionScreen());
   }
 
   void _onShowMnemonic(BuildContext context) async {

--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -1,12 +1,11 @@
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/recovery/view_mnemonic_screen.dart';
+import 'package:danawallet/screens/settings/wallet/confirm_reset_wallet.dart';
 import 'package:danawallet/screens/settings/wallet/confirm_wallet_deletion.dart';
 import 'package:danawallet/screens/settings/widgets/settings_list_tile.dart';
 import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:danawallet/services/backup_service.dart';
-import 'package:danawallet/states/chain_state.dart';
-import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -61,29 +60,8 @@ class WalletSettingsScreen extends StatelessWidget {
     }
   }
 
-  Future<void> _onResetToBirthdayButtonPressed(BuildContext context) async {
-    final confirmed = await showConfirmationAlertDialog(
-        'Confirm resetting wallet data',
-        "Are you sure you want to reset your wallet data? Only do this if you think your wallet data is corrupted, as you will lose valuable data like transaction history.");
-
-    if (confirmed && context.mounted) {
-      final walletState = Provider.of<WalletState>(context, listen: false);
-      final chainState = Provider.of<ChainState>(context, listen: false);
-      final scanProgress =
-          Provider.of<SyncProgressNotifier>(context, listen: false);
-
-      // first interrupt the sync process if this is still running
-      await scanProgress.interruptSync();
-
-      // clear cached start height from sync history
-      chainState.clearSyncHistory();
-
-      // reset wallet data
-      await walletState.resetToBirthday();
-
-      // go to home screen after resetting
-      if (context.mounted) goToHomeScreen(context);
-    }
+  void _onResetToBirthdayButtonPressed(BuildContext context) {
+    goToScreen(context, const ConfirmWalletResetScreen());
   }
 
   void _onWipeWalletButtonPressed(BuildContext context) {

--- a/lib/widgets/icons/circular_icon.dart
+++ b/lib/widgets/icons/circular_icon.dart
@@ -1,28 +1,18 @@
-import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/constants.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 
 class CircularIcon extends StatelessWidget {
-  final String iconPath;
-  final double? iconHeight;
+  final Widget icon;
   final double radius;
   final Color color;
 
   const CircularIcon(
       {super.key,
-      required this.iconPath,
+      required this.icon,
       required this.radius,
-      this.iconHeight,
       this.color = danaBlue});
   @override
   Widget build(BuildContext context) {
-    final icon = SvgPicture.asset(
-      height: iconHeight,
-      iconPath,
-      colorFilter: ColorFilter.mode(Bitcoin.white, BlendMode.srcIn),
-    );
-
     return CircleAvatar(
       radius: radius,
       backgroundColor: color,

--- a/lib/widgets/info_widget.dart
+++ b/lib/widgets/info_widget.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/widgets/icons/circular_icon.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 
 class InfoWidget extends StatelessWidget {
   final String iconPath;
@@ -17,11 +18,17 @@ class InfoWidget extends StatelessWidget {
       required this.group});
   @override
   Widget build(BuildContext context) {
+    final icon = SvgPicture.asset(
+      height: null,
+      iconPath,
+      colorFilter: ColorFilter.mode(Bitcoin.white, BlendMode.srcIn),
+    );
+
     return Row(
       children: [
         CircularIcon(
           radius: 25,
-          iconPath: iconPath,
+          icon: icon,
         ),
         const SizedBox(
           width: 20,


### PR DESCRIPTION
Replace the single popups with a full screen for confirming wallet deletion and resetting.