### PR TITLE
feat(ui): mark 'reset wallet data' as destructive

### DIFF
--- a/lib/screens/settings/wallet/wallet_settings_screen.dart
+++ b/lib/screens/settings/wallet/wallet_settings_screen.dart
@@ -33,6 +33,7 @@ class WalletSettingsScreen extends StatelessWidget {
         title: 'Reset wallet data',
         subtitle: 'Reset wallet data to its birthday',
         onTap: () => _onResetToBirthdayButtonPressed(context),
+        isDestructive: true,
       ),
       _WalletSettingsItem(
         icon: Icons.delete_outline,


### PR DESCRIPTION
Mark the reset wallet data option as destructive by changing the title and icon color to red.