### PR TITLE
fix(db): split migration into separate statements

### DIFF
--- a/lib/repositories/database_helper.dart
+++ b/lib/repositories/database_helper.dart
@@ -51,8 +51,13 @@ class DatabaseHelper {
 
     while (currentVersion < migrations.length) {
       final migration = await rootBundle.loadString(migrations[currentVersion]);
-      Logger().d(migration);
-      await db.execute(migration);
+      final statements =
+          migration.split(';').map((s) => s.trim()).where((s) => s.isNotEmpty);
+
+      for (final statement in statements) {
+        Logger().d(statement);
+        await db.execute(statement);
+      }
       currentVersion++;
     }
   }


### PR DESCRIPTION
Android does not support multiple statements in a single migration. To curcumvent this, we split the migration into separate statements and execute them separately.