### PR TITLE
fix(db): enable foreign_keys pragma after migration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,6 +52,9 @@ void main() async {
     await migrateTxHistoryFromSharedPreferences(spWallet.getChangeAddress());
   }
 
+  // after database migration, enable foreign_keys pragma
+  DatabaseHelper.instance.enableForeignKeysPragma();
+
   final walletState = await WalletState.create();
   final scanNotifier = await SyncProgressNotifier.create();
   final chainState = ChainState();

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -49,6 +49,9 @@ void main() async {
     await migrateTxHistoryFromSharedPreferences(spWallet.getChangeAddress());
   }
 
+  // after database migration, enable foreign_keys pragma
+  DatabaseHelper.instance.enableForeignKeysPragma();
+
   final walletState = await WalletState.create();
   final scanNotifier = await SyncProgressNotifier.create();
   final chainState = ChainState();

--- a/lib/repositories/database_helper.dart
+++ b/lib/repositories/database_helper.dart
@@ -36,14 +36,16 @@ class DatabaseHelper {
     // database version is the number of migrations
     final version = migrations.length;
 
-    return await openDatabase(path,
-        version: version,
-        onUpgrade: (db, oldVersion, newVersion) =>
-            _performMigrations(db, oldVersion, migrations),
-        onConfigure: _onConfigure);
+    return await openDatabase(
+      path,
+      version: version,
+      onUpgrade: (db, oldVersion, newVersion) =>
+          _performMigrations(db, oldVersion, migrations),
+    );
   }
 
-  Future<void> _onConfigure(Database db) async {
+  Future<void> enableForeignKeysPragma() async {
+    final db = await database;
     await db.execute("PRAGMA foreign_keys = ON");
   }
 


### PR DESCRIPTION
Database migration is difficult to do with the foreign_keys pragma, so we delay activating this pragma until after migrations have been completed.