### PR TITLE
refactor(sync): move syncing logic to synchronization service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,7 +56,7 @@ void main() async {
   DatabaseHelper.instance.enableForeignKeysPragma();
 
   final walletState = await WalletState.create();
-  final scanNotifier = await SyncProgressNotifier.create();
+  final scanNotifier = await SyncProgressState.create();
   final chainState = ChainState();
   final contactsState = ContactsState();
   final fiatExchangeRate = await FiatExchangeRateState.create();

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -53,7 +53,7 @@ void main() async {
   DatabaseHelper.instance.enableForeignKeysPragma();
 
   final walletState = await WalletState.create();
-  final scanNotifier = await SyncProgressNotifier.create();
+  final scanNotifier = await SyncProgressState.create();
   final chainState = ChainState();
   final contactsState = ContactsState();
   final fiatExchangeRate = await FiatExchangeRateState.create();

--- a/lib/screens/onboarding/overview.dart
+++ b/lib/screens/onboarding/overview.dart
@@ -46,8 +46,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
     final walletState = Provider.of<WalletState>(context, listen: false);
     final chainState = Provider.of<ChainState>(context, listen: false);
     final contactsState = Provider.of<ContactsState>(context, listen: false);
-    final scanProgress =
-        Provider.of<SyncProgressNotifier>(context, listen: false);
+    final scanProgress = Provider.of<SyncProgressState>(context, listen: false);
 
     final blindbitUrl = network.defaultBlindbitUrl;
 

--- a/lib/screens/onboarding/recovery/seed_phrase.dart
+++ b/lib/screens/onboarding/recovery/seed_phrase.dart
@@ -51,7 +51,7 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
       final chainState = Provider.of<ChainState>(context, listen: false);
       final contactsState = Provider.of<ContactsState>(context, listen: false);
       final scanProgress =
-          Provider.of<SyncProgressNotifier>(context, listen: false);
+          Provider.of<SyncProgressState>(context, listen: false);
 
       // Get birthday: navigate to picker if user knows it, else null
       DateTime? birthday;

--- a/lib/screens/settings/network/network_settings_screen.dart
+++ b/lib/screens/settings/network/network_settings_screen.dart
@@ -50,13 +50,13 @@ class NetworkSettingsScreen extends StatelessWidget {
         'Enter sync height',
         'Enter current sync height (numeric value)');
     if (syncHeight is int) {
+      await chainState.interruptSync();
       await walletState.resetToSyncHeight(syncHeight);
-      chainState.clearSyncHistory();
       homeState.showMainScreen();
     } else if (syncHeight is bool && syncHeight) {
       // if no height is provided, we reset to the birthday
+      await chainState.interruptSync();
       await walletState.resetToBirthday();
-      chainState.clearSyncHistory();
       homeState.showMainScreen();
     }
   }

--- a/lib/screens/settings/wallet/confirm_reset_wallet.dart
+++ b/lib/screens/settings/wallet/confirm_reset_wallet.dart
@@ -23,14 +23,9 @@ class ConfirmWalletResetScreen extends StatelessWidget {
   Future<void> onConfirmResetWallet(BuildContext context) async {
     final walletState = Provider.of<WalletState>(context, listen: false);
     final chainState = Provider.of<ChainState>(context, listen: false);
-    final scanProgress =
-        Provider.of<SyncProgressNotifier>(context, listen: false);
 
-    // first interrupt the sync process if this is still running
-    await scanProgress.interruptSync();
-
-    // clear cached start height from sync history
-    chainState.clearSyncHistory();
+    // interrupt current sync
+    await chainState.interruptSync();
 
     // reset wallet data
     await walletState.resetToBirthday();

--- a/lib/screens/settings/wallet/confirm_wallet_deletion.dart
+++ b/lib/screens/settings/wallet/confirm_wallet_deletion.dart
@@ -28,12 +28,9 @@ class ConfirmWalletDeletionScreen extends StatelessWidget {
     final walletState = Provider.of<WalletState>(context, listen: false);
     final homeState = Provider.of<HomeState>(context, listen: false);
     final chainState = Provider.of<ChainState>(context, listen: false);
-    final scanProgress =
-        Provider.of<SyncProgressNotifier>(context, listen: false);
     final contacts = Provider.of<ContactsState>(context, listen: false);
 
-    await scanProgress.interruptSync();
-    chainState.reset();
+    await chainState.reset();
     await walletState.reset();
     await SettingsRepository.instance.resetAll();
     contacts.reset();

--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -553,7 +553,7 @@ class WalletScreenState extends State<WalletScreen> {
   }
 
   Widget buildFundingScreen(String silentPaymentAddress, String? danaAddress,
-      SyncProgressNotifier scanProgress, ChainState chainState) {
+      SyncProgressState scanProgress, ChainState chainState) {
     return Column(
       children: [
         // Show sync progress when actively scanning
@@ -657,7 +657,7 @@ class WalletScreenState extends State<WalletScreen> {
   Widget build(BuildContext context) {
     final walletState = Provider.of<WalletState>(context);
     final exchangeRate = Provider.of<FiatExchangeRateState>(context);
-    final scanProgress = Provider.of<SyncProgressNotifier>(context);
+    final scanProgress = Provider.of<SyncProgressState>(context);
     final chainState = Provider.of<ChainState>(context);
     final danaAddress = walletState.danaAddress;
 

--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -558,7 +558,7 @@ class WalletScreenState extends State<WalletScreen> {
       children: [
         // Show sync progress when actively scanning
         Visibility(
-            visible: scanProgress.isScanning,
+            visible: scanProgress.isSyncing,
             maintainAnimation: true,
             maintainSize: true,
             maintainState: true,
@@ -685,7 +685,7 @@ class WalletScreenState extends State<WalletScreen> {
               children: [
                 // Show sync progress when actively scanning
                 Visibility(
-                    visible: scanProgress.isScanning,
+                    visible: scanProgress.isSyncing,
                     maintainAnimation: true,
                     maintainSize: true,
                     maintainState: true,

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -15,7 +15,7 @@ import 'package:logger/logger.dart';
 class SynchronizationService {
   WalletState walletState;
   ChainState chainState;
-  SyncProgressNotifier syncProgress;
+  SyncProgressState syncProgress;
 
   Timer? _timer;
   Completer? _completer;

--- a/lib/services/synchronization_service.dart
+++ b/lib/services/synchronization_service.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:danawallet/constants.dart';
+import 'package:danawallet/extensions/network.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
+import 'package:danawallet/generated/rust/api/wallet.dart';
 import 'package:danawallet/global_functions.dart';
+import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
@@ -12,21 +15,16 @@ import 'package:logger/logger.dart';
 class SynchronizationService {
   WalletState walletState;
   ChainState chainState;
-  SyncProgressNotifier scanProgress;
-
-  // first sync will set the start height, all other syncs will keep the same height
-  // this is useful if we receive an error while syncing, and restart the sync process.
-  // this way, we make it explicit that we're continuing from the last sync,
-  // instead of completely restarting.
-  int? _startHeight;
+  SyncProgressNotifier syncProgress;
 
   Timer? _timer;
+  Completer? _completer;
   final Duration _interval = const Duration(seconds: 10);
 
   SynchronizationService(
       {required this.chainState,
       required this.walletState,
-      required this.scanProgress});
+      required this.syncProgress});
 
   Future<void> startSyncTimer(bool immediate) async {
     Logger().i("Starting sync service");
@@ -57,6 +55,7 @@ class SynchronizationService {
   }
 
   Future<void> _performTask() async {
+    _completer = Completer();
     try {
       if (!chainState.available) {
         //attempt to reconnect to the chain state
@@ -74,6 +73,7 @@ class SynchronizationService {
       // e.g. a green or red circle based on whether we have connection issues
       displayError("Sync failed", e);
     }
+    _completer?.complete();
   }
 
   Future<void> _scheduleNextTask() async {
@@ -102,20 +102,44 @@ class SynchronizationService {
     }
 
     if (walletState.lastSync! < chainState.tip) {
-      if (!scanProgress.isScanning) {
-        Logger().i("Starting sync");
+      Logger().i("Starting sync");
 
-        // set start height if not yet set
-        _startHeight ??= walletState.lastSync!;
+      // set sync start height to next block after the last synced block
+      final fromHeight = walletState.lastSync! + 1;
+      final toHeight = chainState.tip;
 
-        await scanProgress.scan(walletState, _startHeight!, chainState.tip);
+      await syncProgress.activate(fromHeight, toHeight);
+
+      try {
+        await _syncToHeight(fromHeight, toHeight);
+        // if we finished syncing, clear and deactivate the sync progress.
+        syncProgress.deactivate(true);
+      } catch (e) {
+        // if we encountered an error, notify the sync progress to deactivate,
+        // but don't clear sync progress in case we want to continue.
+        syncProgress.deactivate(false);
       }
     }
+  }
 
-    if (chainState.tip < walletState.lastSync!) {
-      // not sure what we should do here, that's really bad
-      Logger().e('Current height is less than wallet last scan');
+  Future<void> _syncToHeight(int fromHeight, int toHeight) async {
+    final wallet = await walletState.getWalletFromSecureStorage();
+    final settings = SettingsRepository.instance;
+    final blindbitUrl = await settings.getBlindbitUrl() ??
+        chainState.network.defaultBlindbitUrl;
+    final dustLimit = await settings.getDustLimit() ?? defaultDustLimit;
+
+    if (walletState.lastSync == null) {
+      throw Exception("Last sync is null");
     }
+
+    await wallet.syncToHeight(
+      fromHeight: fromHeight,
+      toHeight: toHeight,
+      blindbitUrl: blindbitUrl,
+      dustLimit: BigInt.from(dustLimit),
+      ownedOutpoints: walletState.outpointsToScan,
+    );
   }
 
   Future<void> _initializeLastSync() async {
@@ -133,12 +157,19 @@ class SynchronizationService {
     walletState.lastSync = blockHeight;
   }
 
-  void stopSyncTimer() {
-    Logger().i("Stopping sync service");
-    _timer?.cancel();
+  Future<void> interrupt() async {
+    Logger().i("Interrupting sync task");
+    // interrupt currently running sync
+    SpWallet.interruptSync();
+
+    // wait until the task has completed
+    await _completer?.future;
   }
 
-  void clearSyncHistory() {
-    _startHeight = null;
+  Future<void> reset() async {
+    // interrupt the sync task
+    await interrupt();
+    // cancel the timer, don't run follow-up sync attempts
+    _timer?.cancel();
   }
 }

--- a/lib/states/chain_state.dart
+++ b/lib/states/chain_state.dart
@@ -40,7 +40,7 @@ class ChainState extends ChangeNotifier {
       SyncProgressNotifier scanProgress, bool immediate) {
     // start sync service & timer
     _synchronizationService = SynchronizationService(
-        chainState: this, walletState: walletState, scanProgress: scanProgress);
+        chainState: this, walletState: walletState, syncProgress: scanProgress);
     _synchronizationService.startSyncTimer(immediate);
   }
 
@@ -83,12 +83,12 @@ class ChainState extends ChangeNotifier {
     }
   }
 
-  void clearSyncHistory() {
-    _synchronizationService.clearSyncHistory();
+  Future<void> interruptSync() async {
+    await _synchronizationService.interrupt();
   }
 
-  void reset() {
-    _synchronizationService.stopSyncTimer();
+  Future<void> reset() async {
+    await _synchronizationService.reset();
     _tip = null;
     _blindbitUrl = null;
     _network = null;

--- a/lib/states/chain_state.dart
+++ b/lib/states/chain_state.dart
@@ -36,11 +36,11 @@ class ChainState extends ChangeNotifier {
     _network = network;
   }
 
-  void startSyncService(WalletState walletState,
-      SyncProgressNotifier scanProgress, bool immediate) {
+  void startSyncService(
+      WalletState walletState, SyncProgressState syncProgress, bool immediate) {
     // start sync service & timer
     _synchronizationService = SynchronizationService(
-        chainState: this, walletState: walletState, syncProgress: scanProgress);
+        chainState: this, walletState: walletState, syncProgress: syncProgress);
     _synchronizationService.startSyncTimer(immediate);
   }
 

--- a/lib/states/sync_progress_notifier.dart
+++ b/lib/states/sync_progress_notifier.dart
@@ -1,32 +1,25 @@
 import 'dart:async';
 
-import 'package:danawallet/constants.dart';
-import 'package:danawallet/extensions/network.dart';
 import 'package:danawallet/generated/rust/api/stream.dart';
-import 'package:danawallet/generated/rust/api/wallet.dart';
-import 'package:danawallet/repositories/settings_repository.dart';
-import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 
 class SyncProgressNotifier extends ChangeNotifier {
-  Completer? _completer;
+  bool isSyncing = false;
   double? progress;
-  late int startHeight;
-  late int endHeight;
+  int? _fromHeight;
+  late int _toHeight;
 
   late StreamSubscription syncProgressSubscription;
-
-  bool get isScanning => _completer != null && !_completer!.isCompleted;
 
   // private constructor
   SyncProgressNotifier._();
 
   Future<void> _initialize() async {
     syncProgressSubscription = createSyncProgressStream().listen(((current) {
-      double scanned = (current - startHeight).toDouble();
-      double total = (endHeight - startHeight).toDouble();
+      double scanned = (current - _fromHeight!).toDouble();
+      double total = (_toHeight - _fromHeight!).toDouble();
       double progress = scanned / total;
-      if (current != endHeight) {
+      if (current != _toHeight) {
         this.progress = progress;
 
         notifyListeners();
@@ -46,60 +39,26 @@ class SyncProgressNotifier extends ChangeNotifier {
     super.dispose();
   }
 
-  void activate() {
-    _completer = Completer();
+  Future<void> activate(int fromHeight, int toHeight) async {
+    // if a start height has already been set, we ignore the start height variable
+    // this is because we might be continuing from a previous sync progress sync point,
+    // which got interrupted by an error
+    _fromHeight ??= fromHeight;
+    // we always set the end height
+    _toHeight = toHeight;
+
+    isSyncing = true;
     progress = null;
     notifyListeners();
   }
 
-  void deactivate() {
-    _completer?.complete();
+  void deactivate(bool clear) {
+    isSyncing = false;
     progress = null;
+    if (clear) {
+      _fromHeight = null;
+    }
+
     notifyListeners();
-  }
-
-  Future<void> scan(
-      WalletState walletState, int startHeight, int chainTip) async {
-    this.startHeight = startHeight;
-    endHeight = chainTip;
-
-    // start syncing from the first block after our last sync
-    // we ignore the startHeight here, because we may be continuing from another sync
-    final fromHeight = walletState.lastSync! + 1;
-    final toHeight = chainTip;
-
-    try {
-      final wallet = await walletState.getWalletFromSecureStorage();
-      final settings = SettingsRepository.instance;
-      final blindbitUrl = await settings.getBlindbitUrl() ??
-          walletState.network.defaultBlindbitUrl;
-      final dustLimit = await settings.getDustLimit() ?? defaultDustLimit;
-
-      if (walletState.lastSync == null) {
-        throw Exception("Last scan is null");
-      }
-
-      activate();
-      await wallet.syncToHeight(
-        fromHeight: fromHeight,
-        toHeight: toHeight,
-        blindbitUrl: blindbitUrl,
-        dustLimit: BigInt.from(dustLimit),
-        ownedOutpoints: walletState.outpointsToScan,
-      );
-    } catch (e) {
-      deactivate();
-      rethrow;
-    }
-    deactivate();
-  }
-
-  Future<void> interruptSync() async {
-    if (isScanning) {
-      SpWallet.interruptSync();
-
-      // this makes sure the scan function has been terminated
-      await _completer?.future;
-    }
   }
 }

--- a/lib/states/sync_progress_notifier.dart
+++ b/lib/states/sync_progress_notifier.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:danawallet/generated/rust/api/stream.dart';
 import 'package:flutter/material.dart';
 
-class SyncProgressNotifier extends ChangeNotifier {
+class SyncProgressState extends ChangeNotifier {
   bool isSyncing = false;
   double? progress;
   int? _fromHeight;
@@ -12,7 +12,7 @@ class SyncProgressNotifier extends ChangeNotifier {
   late StreamSubscription syncProgressSubscription;
 
   // private constructor
-  SyncProgressNotifier._();
+  SyncProgressState._();
 
   Future<void> _initialize() async {
     syncProgressSubscription = createSyncProgressStream().listen(((current) {
@@ -27,8 +27,8 @@ class SyncProgressNotifier extends ChangeNotifier {
     }));
   }
 
-  static Future<SyncProgressNotifier> create() async {
-    final instance = SyncProgressNotifier._();
+  static Future<SyncProgressState> create() async {
+    final instance = SyncProgressState._();
     await instance._initialize();
     return instance;
   }


### PR DESCRIPTION
Move sync logic out of the sync progress notifier and into the synchronization service. The sync progress notifier should be limited to notifying the screens, not handling the syncing itself.