### PR TITLE
feat(txhistory): sort by confirmation height

### DIFF
--- a/lib/repositories/transactions_repository.dart
+++ b/lib/repositories/transactions_repository.dart
@@ -142,8 +142,9 @@ class TransactionsRepository {
       String receiveCode, String changeCode) async {
     final db = await _db;
 
-    final transactions =
-        await db.query('transactions', orderBy: 'created_at DESC');
+    final transactions = await db.query('transactions',
+        orderBy:
+            'CASE WHEN confirmation_height IS NULL THEN 0 ELSE 1 END, confirmation_height DESC');
 
     final result = <RecordedTransaction>[];
 


### PR DESCRIPTION
Sort by confirmation height (descending, aka newest transactions first). To make sure we're showing unconfirmed transactions as the top, we give them the value '0'.

Closes #374 