### PR TITLE
fix(ui, android): wrap main screen column in a SafeArea

### DIFF
--- a/lib/widgets/skeletons/main_screen_skeleton.dart
+++ b/lib/widgets/skeletons/main_screen_skeleton.dart
@@ -29,7 +29,8 @@ class MainScreenSkeleton extends StatelessWidget {
               child: const Icon(Icons.add, color: Colors.white),
             )
           : null,
-      body: Column(
+      body: SafeArea(
+          child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Title
@@ -54,7 +55,7 @@ class MainScreenSkeleton extends StatelessWidget {
           // Optional footer
           if (footer != null) footer!,
         ],
-      ),
+      )),
     );
   }
 }


### PR DESCRIPTION
This has no noticeable difference on linux, but will make sure the screen title stays within a safe area.