### PR TITLE
refactor(justfile): drop recipes for manually building binaries

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,9 +12,6 @@ run flags="":
     #!/bin/sh
     just gen
 
-    # always build rust binaries if building for android
-    [[ {{platform}} == "android-arm64" ]] && just build-android
-
     flags={{flags}}
     flags="$flags --flavor local"
     flags="$flags --target lib/main_local.dart"
@@ -28,14 +25,8 @@ run-release:
 format:
     fvm dart format ./lib
 
-clean-bin:
-    cd rust && just clean-bin
 gen:
     cd rust && just gen
-build-emulator:
-    cd rust && just build-emulator
-build-android:
-    cd rust && just build-android
 
 inspect-db:
     #!/bin/sh

--- a/rust/justfile
+++ b/rust/justfile
@@ -1,13 +1,4 @@
-default: clean-bin build-emulator build-android
-
-clean-bin:
-    rm -fRd ../android/app/src/main/jniLibs/*
+default: gen
 
 gen:
     flutter_rust_bridge_codegen generate --config-file ../flutter_rust_bridge.yaml --enable-lifetime
-
-build-emulator:
-    cargo ndk -t x86_64 -o ../android/app/src/main/jniLibs build
-
-build-android:
-    cargo ndk -o ../android/app/src/main/jniLibs build --release


### PR DESCRIPTION
Binaries should be auto-built by cargokit, drop the related recipes for manually building them.