### PR TITLE
refactor: drop url_launcher dependency override

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1079,7 +1079,7 @@ packages:
     source: hosted
     version: "6.3.2"
   url_launcher_android:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: url_launcher_android
       sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,10 +49,6 @@ dependencies:
   package_info_plus: ^9.0.0
   intl: ^0.19.0
 
-dependency_overrides:
-  # Pin url_launcher_android to avoid AGP 8.9.1 requirement (androidx.browser:1.9.0, androidx.core:1.17.0)
-  url_launcher_android: 6.3.20
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
We deemed that this manual dependency override wasn't actually needed, but never bothered to remove it.