### PR TITLE
refactor: remove unused pin guard screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:danawallet/repositories/owned_outputs_repository.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/repositories/transactions_repository.dart';
 import 'package:danawallet/repositories/wallet_repository.dart';
+import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/screens/onboarding/introduction.dart';
 import 'package:danawallet/screens/onboarding/register_dana_address.dart';
 import 'package:danawallet/services/app_info_service.dart';
@@ -20,7 +21,6 @@ import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
 import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
-import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:logger/logger.dart';
@@ -106,7 +106,7 @@ void main() async {
     if (addressRegistrationNeeded) {
       landingPage = const RegisterDanaAddressScreen();
     } else {
-      landingPage = const PinGuard();
+      landingPage = const HomeScreen();
     }
   } else {
     // no wallet is loaded, so we go to the introduction screen

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -9,6 +9,7 @@ import 'package:danawallet/repositories/owned_outputs_repository.dart';
 import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:danawallet/repositories/transactions_repository.dart';
 import 'package:danawallet/repositories/wallet_repository.dart';
+import 'package:danawallet/screens/home/home.dart' show HomeScreen;
 import 'package:danawallet/screens/onboarding/register_dana_address.dart';
 import 'package:danawallet/screens/onboarding/introduction.dart';
 import 'package:danawallet/services/app_info_service.dart';
@@ -19,7 +20,6 @@ import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
 import 'package:danawallet/states/sync_progress_notifier.dart';
 import 'package:danawallet/states/wallet_state.dart';
-import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -108,7 +108,7 @@ void main() async {
     if (addressRegistrationNeeded) {
       landingPage = const RegisterDanaAddressScreen();
     } else {
-      landingPage = const PinGuard();
+      landingPage = const HomeScreen();
     }
   } else {
     // no wallet is loaded, so we go to the introduction screen

--- a/lib/screens/onboarding/overview.dart
+++ b/lib/screens/onboarding/overview.dart
@@ -4,6 +4,7 @@ import 'package:danawallet/extensions/network.dart';
 import 'package:danawallet/generated/rust/api/bip39.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
 import 'package:danawallet/global_functions.dart';
+import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/screens/onboarding/choose_network.dart';
 import 'package:danawallet/screens/onboarding/register_dana_address.dart';
 import 'package:danawallet/screens/onboarding/onboarding_skeleton.dart';
@@ -15,7 +16,6 @@ import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button_outlined.dart';
 import 'package:danawallet/widgets/info_widget.dart';
-import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sizer/sizer.dart';
@@ -71,7 +71,7 @@ class _OverviewScreenState extends State<OverviewScreen> {
       // skip the dana address registration if we are currently offline, or using regtest
       Widget nextScreen;
       if (!connected || network == Network.regtest) {
-        nextScreen = const PinGuard();
+        nextScreen = const HomeScreen();
       } else {
         nextScreen = const RegisterDanaAddressScreen();
       }

--- a/lib/screens/onboarding/recovery/seed_phrase.dart
+++ b/lib/screens/onboarding/recovery/seed_phrase.dart
@@ -4,6 +4,7 @@ import 'package:danawallet/data/enums/warning_type.dart';
 import 'package:danawallet/extensions/network.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
 import 'package:danawallet/global_functions.dart';
+import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/screens/onboarding/recovery/birthday_picker_screen.dart';
 import 'package:danawallet/screens/onboarding/register_dana_address.dart';
 import 'package:danawallet/states/chain_state.dart';
@@ -13,7 +14,6 @@ import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/loading_widget.dart';
 import 'package:danawallet/widgets/pills/mnemonic_input_pill_box.dart';
-import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:danawallet/widgets/skeletons/screen_skeleton.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -110,7 +110,7 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
       if (context.mounted) {
         Widget nextScreen = goToDanaAddressSetup
             ? const RegisterDanaAddressScreen()
-            : const PinGuard();
+            : const HomeScreen();
         Navigator.pushAndRemoveUntil(
             context,
             MaterialPageRoute(builder: (context) => nextScreen),

--- a/lib/screens/onboarding/register_dana_address.dart
+++ b/lib/screens/onboarding/register_dana_address.dart
@@ -5,6 +5,7 @@ import 'package:danawallet/constants.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/repositories/wallet_repository.dart';
+import 'package:danawallet/screens/home/home.dart';
 import 'package:danawallet/screens/onboarding/onboarding_skeleton.dart';
 import 'package:danawallet/services/dana_address_service.dart';
 import 'package:danawallet/states/contacts_state.dart';
@@ -12,7 +13,6 @@ import 'package:danawallet/states/wallet_state.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button.dart';
 import 'package:danawallet/widgets/buttons/footer/footer_button_outlined.dart';
 import 'package:danawallet/widgets/loading_widget.dart';
-import 'package:danawallet/widgets/pin_guard.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
@@ -328,7 +328,7 @@ class _RegisterDanaAddressScreenState extends State<RegisterDanaAddressScreen> {
         if (mounted) {
           Navigator.pushAndRemoveUntil(
             context,
-            MaterialPageRoute(builder: (context) => const PinGuard()),
+            MaterialPageRoute(builder: (context) => const HomeScreen()),
             (Route<dynamic> route) => false,
           );
         }
@@ -346,7 +346,7 @@ class _RegisterDanaAddressScreenState extends State<RegisterDanaAddressScreen> {
   void _onSkip() {
     Navigator.pushAndRemoveUntil(
       context,
-      MaterialPageRoute(builder: (context) => const PinGuard()),
+      MaterialPageRoute(builder: (context) => const HomeScreen()),
       (Route<dynamic> route) => false,
     );
   }


### PR DESCRIPTION
Instead of wrapping the home screen in a pin guard, just redirect to the home screen directly. The pin guard was always set to forward immediately, so this has no UX difference.