### PR TITLE
refactor: make foreground sync service methods static

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,7 @@ void main() async {
     databaseFactory = databaseFactoryFfi;
   } else if (Platform.isAndroid) {
     FlutterForegroundTask.initCommunicationPort();
-    ForegroundSyncService.instance.initialize();
+    ForegroundSyncService.initialize();
   } else {
     Logger().e('Dana wallet is not supported on this platform');
     exit(1);

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -40,7 +40,7 @@ void main() async {
     databaseFactory = databaseFactoryFfi;
   } else if (Platform.isAndroid) {
     FlutterForegroundTask.initCommunicationPort();
-    ForegroundSyncService.instance.initialize();
+    ForegroundSyncService.initialize();
   } else {
     Logger().e('Dana wallet is not supported on this platform');
     exit(1);

--- a/lib/services/foreground_sync_service.dart
+++ b/lib/services/foreground_sync_service.dart
@@ -3,9 +3,6 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:logger/logger.dart';
 
 class ForegroundSyncService {
-  ForegroundSyncService._();
-  static final instance = ForegroundSyncService._();
-
   static const String _notificationChannelId = 'dana_sync';
   static const String _notificationChannelName = 'Dana background sync';
   static const String _notificationChannelDescription =
@@ -15,7 +12,7 @@ class ForegroundSyncService {
       'Keeping your wallet up to date';
 
   /// Call once at app startup, before runApp().
-  void initialize() {
+  static void initialize() {
     FlutterForegroundTask.init(
       androidNotificationOptions: AndroidNotificationOptions(
         channelId: _notificationChannelId,
@@ -30,7 +27,7 @@ class ForegroundSyncService {
 
   /// Start the foreground service. Safe to call even if already running.
   /// Does not block startup — await this fire-and-forget with unawaited().
-  Future<void> start() async {
+  static Future<void> start() async {
     if (await FlutterForegroundTask.isRunningService) {
       Logger().i('Android foreground service already running');
       return;
@@ -52,7 +49,7 @@ class ForegroundSyncService {
     }
   }
 
-  Future<void> stop() async {
+  static Future<void> stop() async {
     if (!await FlutterForegroundTask.isRunningService) return;
     await FlutterForegroundTask.stopService();
     Logger().i('Android foreground service stopped');

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -26,7 +26,7 @@ class SyncService {
   bool _callbacksRegistered = false;
 
   // in case we are doing in-process syncing
-  InProcessSyncService? _service;
+  InProcessSyncService? _inProcessSyncService;
 
   SyncService({
     required ChainState chainState,
@@ -67,13 +67,12 @@ class SyncService {
     await _permissionState.refresh();
     if (!_permissionState.notificationGranted) {
       if (await FlutterForegroundTask.isRunningService) {
-        await ForegroundSyncService.instance.stop();
+        await ForegroundSyncService.stop();
       }
       Logger().w('Notification permission missing');
       return false;
     }
-
-    await ForegroundSyncService.instance.start();
+    await ForegroundSyncService.start();
 
     if (await FlutterForegroundTask.isRunningService) {
       _chainState.startChainPoller(
@@ -90,13 +89,13 @@ class SyncService {
   }
 
   void startInProcess() {
-    _service = InProcessSyncService(
+    _inProcessSyncService = InProcessSyncService(
       syncProgress: _syncProgress,
       walletState: _walletState,
     );
     _chainState.startChainPoller(
       true,
-      onTipUpdated: _service!.trySync,
+      onTipUpdated: _inProcessSyncService!.trySync,
       shouldSkipTick: () => _syncProgress.isSyncing,
     );
     return;
@@ -111,11 +110,11 @@ class SyncService {
 
   Future<void> stop() async {
     _chainState.stopChainPoller();
-    if (_service != null) {
+    if (_inProcessSyncService != null) {
       // In-process path: SpWallet.interruptSync() targets the correct (main) isolate.
       await _syncProgress.interruptSync();
-      _service!.dispose();
-      _service = null;
+      _inProcessSyncService!.dispose();
+      _inProcessSyncService = null;
     } else {
       // Foreground-service path: the sync runs in the BG isolate, so we must
       // send the interrupt via IPC and let it call SpWallet.interruptSync() there.
@@ -123,7 +122,7 @@ class SyncService {
       // BG isolate can finish cleanly rather than being killed mid-sync.
       FlutterForegroundTask.sendDataToTask({bgKeyInterrupt: true});
       await _syncProgress.waitForCompletion();
-      await ForegroundSyncService.instance.stop();
+      await ForegroundSyncService.stop();
     }
   }
 }


### PR DESCRIPTION
Instead of using a singleton approach, just make the class methods static.