### PR TITLE
refactor: move onServiceData callbacks to sync service

### DIFF
--- a/lib/services/in_process_sync_service.dart
+++ b/lib/services/in_process_sync_service.dart
@@ -16,11 +16,9 @@ class InProcessSyncService {
   }) : _engine = SyncEngine(
           logTag: 'in-process',
           onSyncStarted: (start, end) {
-            syncProgress.startHeight = start;
-            syncProgress.endHeight = end;
-            syncProgress.activate();
+            syncProgress.activate(start, end);
           },
-          onSyncComplete: (_) => syncProgress.deactivate(),
+          onSyncComplete: (success) => syncProgress.deactivate(success),
           onStateUpdated: (lastSyncOnly) =>
               walletState.refreshAfterSync(lastSyncOnly: lastSyncOnly),
         );

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -58,8 +58,6 @@ class SyncService {
 
   Future<bool> startForeground() async {
     if (!_callbacksRegistered) {
-      FlutterForegroundTask.addTaskDataCallback(_syncProgress.onServiceData);
-      FlutterForegroundTask.addTaskDataCallback(_walletState.onServiceData);
       FlutterForegroundTask.addTaskDataCallback(_onServiceData);
       _callbacksRegistered = true;
     }
@@ -102,9 +100,28 @@ class SyncService {
   }
 
   void _onServiceData(Object data) {
-    if (data is Map && data[bgKeyFatalError] == true) {
+    if (data is! Map) return;
+
+    if (data[bgKeyFatalError] == true) {
       Logger().e('Background isolate reported a fatal error');
       unawaited(onFatalError());
+    }
+
+    // sync progress update
+    if (data.containsKey(bgKeyStartHeight) &&
+        data.containsKey(bgKeyEndHeight)) {
+      int startHeight = (data[bgKeyStartHeight] as num).toInt();
+      int endHeight = (data[bgKeyEndHeight] as num).toInt();
+      _syncProgress.activate(startHeight, endHeight);
+    } else if (data.containsKey(bgKeyComplete)) {
+      bool success = data[bgKeyComplete] as bool;
+      _syncProgress.deactivate(success);
+    }
+
+    // walletState update
+    if (data.containsKey(bgKeyRefresh)) {
+      final lastSyncOnly = data[bgKeyRefresh] as bool;
+      unawaited(_walletState.refreshAfterSync(lastSyncOnly: lastSyncOnly));
     }
   }
 

--- a/lib/states/sync_progress_state.dart
+++ b/lib/states/sync_progress_state.dart
@@ -1,21 +1,17 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/stream.dart';
 import 'package:danawallet/generated/rust/api/wallet.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 class SyncProgressState extends ChangeNotifier {
+  bool isSyncing = false;
   Completer? _completer;
   double? progress;
-  int? startHeight;
-  int? endHeight;
+  int? _startHeight;
+  int? _endHeight;
 
   late StreamSubscription syncProgressSubscription;
-
-  bool get isSyncing => _completer != null && !_completer!.isCompleted;
 
   // private constructor
   SyncProgressState._();
@@ -27,8 +23,8 @@ class SyncProgressState extends ChangeNotifier {
       // bar after deactivate() has already been called.
       if (!isSyncing) return;
 
-      final start = startHeight;
-      final end = endHeight;
+      final start = _startHeight;
+      final end = _endHeight;
       if (start == null || end == null || end <= start) return;
 
       final progress = (current - start) / (end - start);
@@ -47,37 +43,33 @@ class SyncProgressState extends ChangeNotifier {
 
   @override
   void dispose() {
-    if (Platform.isAndroid) {
-      FlutterForegroundTask.removeTaskDataCallback(onServiceData);
-    }
     syncProgressSubscription.cancel();
     super.dispose();
   }
 
-  void activate() {
+  void activate(int startHeight, int endHeight) {
+    // if a start height has already been set, we ignore the start height variable
+    // this is because we might be continuing from a previous sync progress sync point,
+    // which got interrupted by an error
+    _startHeight ??= startHeight;
+    _endHeight = endHeight;
+
+    isSyncing = true;
+
     _completer = Completer();
     progress = null;
     notifyListeners();
   }
 
-  void deactivate() {
-    _completer?.complete();
+  void deactivate(bool clear) {
+    isSyncing = false;
     progress = null;
-    notifyListeners();
-  }
+    _completer?.complete();
 
-  /// Called by the main isolate's service data callback with messages from
-  /// the background sync task.
-  void onServiceData(Object data) {
-    if (data is! Map) return;
-    if (data.containsKey(bgKeyStartHeight) &&
-        data.containsKey(bgKeyEndHeight)) {
-      startHeight = (data[bgKeyStartHeight] as num).toInt();
-      endHeight = (data[bgKeyEndHeight] as num).toInt();
-      activate();
-    } else if (data.containsKey(bgKeyComplete)) {
-      deactivate();
+    if (clear) {
+      _startHeight = null;
     }
+    notifyListeners();
   }
 
   /// Waits for an active scan to complete or be interrupted, then returns.
@@ -87,7 +79,7 @@ class SyncProgressState extends ChangeNotifier {
     if (!isSyncing) return;
     await _completer?.future.timeout(
       const Duration(seconds: 10),
-      onTimeout: deactivate,
+      onTimeout: () => deactivate(true),
     );
   }
 

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/extensions/date_time.dart';
@@ -21,7 +20,6 @@ import 'package:danawallet/repositories/wallet_repository.dart';
 import 'package:danawallet/services/bip353_resolver.dart';
 import 'package:danawallet/services/dana_address_service.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:logger/logger.dart';
 
 class WalletState extends ChangeNotifier {
@@ -90,23 +88,6 @@ class WalletState extends ChangeNotifier {
     if (!_initialized) return;
     await _updateWalletState(lastSyncOnly: lastSyncOnly);
     notifyListeners();
-  }
-
-  void onServiceData(Object data) {
-    if (!_initialized) return;
-    if (data is! Map) return;
-    if (data.containsKey(bgKeyRefresh)) {
-      _updateWalletState(lastSyncOnly: data[bgKeyRefresh] as bool)
-          .then((_) => notifyListeners());
-    }
-  }
-
-  @override
-  void dispose() {
-    if (Platform.isAndroid) {
-      FlutterForegroundTask.removeTaskDataCallback(onServiceData);
-    }
-    super.dispose();
   }
 
   Future<void> reset() async {


### PR DESCRIPTION
Instead of having callbacks on the syncProgress and walletState classes, parse the service data in the sync service and call the high-level method functions.