### PR TITLE
feat(justfile): split run into 'prepare' and 'run'

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-default: run
+default: prepare run
 
 # use fvm if available, else use flutter directly
 flutter := if `which fvm 2> /dev/null || true` != "" { "fvm flutter" }  else { "flutter" }
@@ -8,15 +8,16 @@ platform := `fvm flutter devices --machine | jq .[0].targetPlatform`
 
 git_hash := `git rev-parse HEAD`
 
+prepare:
+    just gen
+    {{flutter}} pub get
+
 run flags="":
     #!/bin/sh
-    just gen
-
     flags={{flags}}
     flags="$flags --flavor local"
     flags="$flags --target lib/main_local.dart"
     flags="$flags --dart-define=GIT_HASH={{git_hash}}"
-
     {{flutter}} run $flags
 
 run-release:


### PR DESCRIPTION
Instead of generating the frb files every time we call just run, do it only when we explicitly call the 'prepare' recipe. The default recipe is now prepare+run instead of only 'run'.