### PR TITLE
refactor: move sync service constructor call to inside orchestrator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,21 +70,13 @@ void main() async {
   final chainState = ChainState();
   final contactsState = ContactsState();
   final fiatExchangeRate = await FiatExchangeRateState.create();
-  SyncOrchestrator? syncOrchestratorRef;
-  final syncService = SyncService(
+
+  final syncOrchestrator = SyncOrchestrator(
     chainState: chainState,
     syncProgress: syncProgress,
     walletState: walletState,
     permissionState: permissionState,
-    onFatalError: () =>
-        syncOrchestratorRef?.restart(fallbackMode: true) ?? Future.value(),
   );
-
-  final syncOrchestrator = SyncOrchestrator(
-    service: syncService,
-    permissionState: permissionState,
-  );
-  syncOrchestratorRef = syncOrchestrator;
 
   // fetch the exchange rate, but don't await the response
   fiatExchangeRate.updateExchangeRate();

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -21,7 +21,7 @@ class SyncService {
   /// Called when the background isolate sends [bgKeyFatalError]. The backend
   /// has already committed to the foreground-service path by the time this
   /// fires, so the caller must trigger a restart to recover into fallback mode.
-  final Future<void> Function() onFatalError;
+  late Future<void> Function() onFatalError;
 
   bool _callbacksRegistered = false;
 
@@ -33,7 +33,6 @@ class SyncService {
     required PermissionState permissionState,
     required SyncProgressState syncProgress,
     required WalletState walletState,
-    required this.onFatalError,
   })  : _chainState = chainState,
         _permissionState = permissionState,
         _syncProgress = syncProgress,

--- a/lib/states/sync_orchestrator.dart
+++ b/lib/states/sync_orchestrator.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 
 import 'package:danawallet/data/enums/sync_enums.dart';
 import 'package:danawallet/services/sync_service.dart';
+import 'package:danawallet/states/chain_state.dart';
 import 'package:danawallet/states/permission_state.dart';
+import 'package:danawallet/states/sync_progress_state.dart';
+import 'package:danawallet/states/wallet_state.dart';
 import 'package:flutter/material.dart';
 
 export 'package:danawallet/services/sync_service.dart' show SyncService;
@@ -30,11 +33,19 @@ class SyncOrchestrator extends ChangeNotifier {
   bool get isRunning => _running;
 
   SyncOrchestrator({
-    required SyncService service,
+    required ChainState chainState,
     required PermissionState permissionState,
-  })  : _service = service,
+    required SyncProgressState syncProgress,
+    required WalletState walletState,
+  })  : _service = SyncService(
+          chainState: chainState,
+          syncProgress: syncProgress,
+          walletState: walletState,
+          permissionState: permissionState,
+        ),
         _permissionState = permissionState {
     _permissionState.addListener(_onPermissionStateChanged);
+    _service.onFatalError = () => restart(fallbackMode: true);
   }
 
   /// Idempotent. Call only after the navigator is live.


### PR DESCRIPTION
The sync service is 'owned' by the sync orchestrator so it makes sense to have it be responsible for constructing it. Without this, we needed to have a circular reference between the sync service and the orchestrator.