### PR TITLE
refactor: start sync orchestrator in same block as other states

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,6 +108,8 @@ void main() async {
     contactsState.initialize(
         walletState.receivePaymentCode, walletState.danaAddress);
 
+    syncOrchestrator.start();
+
     if (addressRegistrationNeeded) {
       landingPage = const RegisterDanaAddressScreen();
     } else {
@@ -136,12 +138,6 @@ void main() async {
       child: SilentPaymentApp(landingPage: landingPage),
     ),
   );
-
-  if (walletLoaded) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      syncOrchestrator.start();
-    });
-  }
 }
 
 class SilentPaymentApp extends StatelessWidget {


### PR DESCRIPTION
The sync orchestrator is started in a post-frame callback block. Based on my experience this does not actually have a different result, so I think this was the result of an earlier version where this was required.