### PR TITLE
fix: set orchestrator.start before redirecting to notification screen

### DIFF
--- a/lib/screens/onboarding/recovery/seed_phrase.dart
+++ b/lib/screens/onboarding/recovery/seed_phrase.dart
@@ -108,6 +108,8 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
       contactsState.initialize(
           walletState.receivePaymentCode, walletState.danaAddress);
 
+      await orchestrator.start();
+
       if (context.mounted) {
         final Widget nextScreen = goToDanaAddressSetup
             ? const RegisterDanaAddressScreen()
@@ -123,8 +125,6 @@ class SeedPhraseScreenState extends State<SeedPhraseScreen> {
             (Route<dynamic> route) => false,
           );
         } else {
-          await orchestrator.start();
-          if (!context.mounted) return;
           Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (context) => nextScreen),


### PR DESCRIPTION
The orchestrator is normally started after connecting to the blindbit instance. There's one exception to this, when we are about to redirect to the notification screen. Here we move the call to before redirecting to this screen.

This means that, after giving the notification permissions, the orchestrator will be restarted.