### PR TITLE
fix(rust): move StateUpdate to api/structs

### DIFF
--- a/lib/services/sync_engine.dart
+++ b/lib/services/sync_engine.dart
@@ -7,7 +7,7 @@ import 'package:danawallet/extensions/outpoint.dart';
 import 'package:danawallet/generated/rust/api/chain.dart';
 import 'package:danawallet/generated/rust/api/stream.dart';
 import 'package:danawallet/generated/rust/api/structs/outpoint.dart';
-import 'package:danawallet/generated/rust/stream.dart';
+import 'package:danawallet/generated/rust/api/structs/state_update.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
 import 'package:danawallet/repositories/owned_outputs_repository.dart';
 import 'package:danawallet/repositories/settings_repository.dart';

--- a/rust/src/api/stream.rs
+++ b/rust/src/api/stream.rs
@@ -1,13 +1,11 @@
-use crate::{
-    frb_generated::StreamSink,
-    logger::{self, LogEntry, LogLevel},
-    stream::{self, StateUpdate},
-};
+use crate::api::structs::state_update::StateUpdate;
+use crate::logger::{LogEntry, LogLevel};
+use crate::{frb_generated::StreamSink, stream};
 
 #[flutter_rust_bridge::frb(sync)]
 pub fn create_log_stream(s: StreamSink<LogEntry>, level: LogLevel, log_dependencies: bool) {
-    logger::init_logger(level.into(), log_dependencies);
-    logger::FlutterLogger::set_stream_sink(s);
+    crate::logger::init_logger(level.into(), log_dependencies);
+    crate::logger::FlutterLogger::set_stream_sink(s);
 }
 
 #[flutter_rust_bridge::frb(sync)]

--- a/rust/src/api/structs/mod.rs
+++ b/rust/src/api/structs/mod.rs
@@ -4,4 +4,5 @@ pub mod network;
 pub mod outpoint;
 pub mod owned_output;
 pub mod recipient;
+pub mod state_update;
 pub mod unsigned_transaction;

--- a/rust/src/api/structs/state_update.rs
+++ b/rust/src/api/structs/state_update.rs
@@ -1,0 +1,15 @@
+use std::collections::HashSet;
+
+use flutter_rust_bridge::frb;
+
+use crate::api::structs::outpoint::OutPoint;
+use crate::api::structs::owned_output::OwnedOutput;
+
+#[derive(Debug)]
+#[frb]
+pub struct StateUpdate {
+    pub blkheight: u32,
+    pub blkhash: String,
+    pub found_outputs: Vec<OwnedOutput>,
+    pub found_inputs: HashSet<OutPoint>,
+}

--- a/rust/src/state/updater.rs
+++ b/rust/src/state/updater.rs
@@ -9,10 +9,9 @@ use spdk_wallet::{
     updater::DiscoveredOutput,
 };
 
-use crate::{
-    api::structs::owned_output::OwnedOutput,
-    stream::{send_sync_progress, send_sync_update, StateUpdate},
-};
+use crate::api::structs::owned_output::OwnedOutput;
+use crate::api::structs::state_update::StateUpdate;
+use crate::stream::{send_sync_progress, send_sync_update};
 
 use anyhow::Result;
 

--- a/rust/src/stream.rs
+++ b/rust/src/stream.rs
@@ -1,22 +1,13 @@
-use std::{collections::HashSet, sync::Mutex};
+use std::sync::Mutex;
 
-use crate::api::structs::owned_output::OwnedOutput;
+use crate::api::structs::state_update::StateUpdate;
 use crate::frb_generated::StreamSink;
-use flutter_rust_bridge::frb;
+
 use lazy_static::lazy_static;
 
 lazy_static! {
     static ref SCAN_PROGRESS_STREAM_SINK: Mutex<Option<StreamSink<u32>>> = Mutex::new(None);
     static ref STATE_UPDATE_STREAM_SINK: Mutex<Option<StreamSink<StateUpdate>>> = Mutex::new(None);
-}
-
-#[derive(Debug)]
-#[frb]
-pub struct StateUpdate {
-    pub blkheight: u32,
-    pub blkhash: String,
-    pub found_outputs: Vec<OwnedOutput>,
-    pub found_inputs: HashSet<crate::api::structs::outpoint::OutPoint>,
 }
 
 pub fn create_sync_progress_stream(s: StreamSink<u32>) {


### PR DESCRIPTION
Since we use StateUpdate on the flutter side as well as the rust side, this struct should be in api/structs.