### PR TITLE
refactor: send state updates to main isolate for processing

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -56,7 +56,7 @@ const String nameServerDevTestnet =
 const String bgKeyStartHeight = 'startHeight';
 const String bgKeyEndHeight = 'endHeight';
 const String bgKeyComplete = 'complete';
-const String bgKeyRefresh = 'refresh';
+const String bgKeyStateUpdate = 'stateUpdate';
 const String bgKeyInterrupt = 'interrupt';
 const String bgKeyFatalError = 'fatalError';
 

--- a/lib/services/in_process_sync_service.dart
+++ b/lib/services/in_process_sync_service.dart
@@ -1,3 +1,4 @@
+import 'package:danawallet/generated/rust/api/structs/state_update.dart';
 import 'package:danawallet/services/sync_engine.dart';
 import 'package:danawallet/states/sync_progress_state.dart';
 import 'package:danawallet/states/wallet_state.dart';
@@ -19,8 +20,8 @@ class InProcessSyncService {
             syncProgress.activate(start, end);
           },
           onSyncComplete: (success) => syncProgress.deactivate(success),
-          onStateUpdated: (lastSyncOnly) =>
-              walletState.refreshAfterSync(lastSyncOnly: lastSyncOnly),
+          onStateUpdate: (update) =>
+              walletState.processUpdate(StateUpdate.decode(encoded: update)),
         );
 
   Future<void> trySync() => _engine.trySync();

--- a/lib/services/sync_engine.dart
+++ b/lib/services/sync_engine.dart
@@ -3,10 +3,8 @@ import 'dart:async';
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/extensions/date_time.dart';
 import 'package:danawallet/extensions/network.dart';
-import 'package:danawallet/extensions/outpoint.dart';
 import 'package:danawallet/generated/rust/api/chain.dart';
 import 'package:danawallet/generated/rust/api/stream.dart';
-import 'package:danawallet/generated/rust/api/structs/outpoint.dart';
 import 'package:danawallet/generated/rust/api/structs/state_update.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
 import 'package:danawallet/repositories/owned_outputs_repository.dart';
@@ -30,8 +28,7 @@ class SyncEngine {
   /// on error so callers can deactivate progress indicators in both cases.
   final void Function(bool success) onSyncComplete;
 
-  /// Called after each [StateUpdate] to refresh UI state from the DB.
-  final Future<void> Function(bool lastSyncOnly) onStateUpdated;
+  final Future<void> Function(String encodedUpdate) onStateUpdate;
 
   final String _logTag;
 
@@ -48,67 +45,14 @@ class SyncEngine {
   SyncEngine({
     required this.onSyncStarted,
     required this.onSyncComplete,
-    required this.onStateUpdated,
+    required this.onStateUpdate,
     String logTag = 'sync',
   }) : _logTag = logTag {
     _syncResultSubscription = createSyncResultStream().listen(_onSyncResult);
   }
 
-  Future<void> _onSyncResult(StateUpdate event) async {
-    // Process found outputs (new UTXOs we own)
-    for (final found in event.foundOutputs) {
-      // first, insert the transaction data in the known transactions table
-      await _transactionsRepository.addIncomingTransaction(
-        txid: found.outpoint.txid,
-        confirmationHeight: event.blkheight,
-        confirmationBlockhash: event.blkhash,
-      );
-
-      // Insert output into database
-      await _ownedOutputsRepository.insertOutput(output: found);
-    }
-
-    List<OutPoint> unknownSpends = [];
-
-    // Process found inputs (our UTXOs being spent)
-    for (final outpoint in event.foundInputs) {
-      // Try to confirm an outgoing transaction
-      final confirmed =
-          await _transactionsRepository.confirmOutgoingTransaction(
-        confirmedOutpointTxid: outpoint.txid,
-        confirmedOutpointVout: outpoint.vout,
-        confirmationHeight: event.blkheight,
-        confirmationBlockhash: event.blkhash,
-      );
-
-      // this output does not have an associated transaction
-      // this can occur if a user imported their seed phrase in multiple wallets
-      // generally we should discourage this, but it's inevitable that it will happen
-      if (!confirmed) {
-        unknownSpends.add(outpoint);
-      }
-    }
-
-    if (unknownSpends.isNotEmpty) {
-      Logger().w(
-          "Unknown spends detected, marking the following outpoints as spent: ${unknownSpends.toDisplayString()}");
-      await _transactionsRepository.addOutgoingTransaction(
-        spentOutpoints: unknownSpends,
-        recipients: [],
-        txid: null,
-        confirmationHeight: event.blkheight,
-        confirmationBlockhash: event.blkhash,
-      );
-    }
-
-    await _walletRepository.saveLastSync(event.blkheight);
-
-    if (event.foundOutputs.isNotEmpty || event.foundInputs.isNotEmpty) {
-      await onStateUpdated(false);
-    } else {
-      await onStateUpdated(true);
-    }
-  }
+  Future<void> _onSyncResult(StateUpdate event) =>
+      onStateUpdate(event.encode());
 
   Future<void> trySync() async {
     if (_isSyncing) {

--- a/lib/services/sync_service.dart
+++ b/lib/services/sync_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:danawallet/constants.dart';
+import 'package:danawallet/generated/rust/api/structs/state_update.dart';
 import 'package:danawallet/services/foreground_sync_service.dart';
 import 'package:danawallet/services/in_process_sync_service.dart';
 import 'package:danawallet/states/chain_state.dart';
@@ -87,9 +88,10 @@ class SyncService {
     }
 
     // walletState update
-    if (data.containsKey(bgKeyRefresh)) {
-      final lastSyncOnly = data[bgKeyRefresh] as bool;
-      unawaited(_walletState.refreshAfterSync(lastSyncOnly: lastSyncOnly));
+    if (data.containsKey(bgKeyStateUpdate)) {
+      final update = data[bgKeyStateUpdate] as String;
+      unawaited(
+          _walletState.processUpdate(StateUpdate.decode(encoded: update)));
     }
   }
 

--- a/lib/services/sync_task_handler.dart
+++ b/lib/services/sync_task_handler.dart
@@ -60,8 +60,8 @@ class SynchronizationTaskHandler extends TaskHandler {
         _endHeight = null;
         FlutterForegroundTask.sendDataToMain({bgKeyComplete: ok});
       },
-      onStateUpdated: (lastSyncOnly) async =>
-          FlutterForegroundTask.sendDataToMain({bgKeyRefresh: lastSyncOnly}),
+      onStateUpdate: (update) async =>
+          FlutterForegroundTask.sendDataToMain({bgKeyStateUpdate: update}),
     );
     unawaited(_engine!.trySync());
   }

--- a/lib/states/wallet_state.dart
+++ b/lib/states/wallet_state.dart
@@ -3,10 +3,12 @@ import 'package:danawallet/constants.dart';
 import 'package:danawallet/data/models/bip353_address.dart';
 import 'package:danawallet/extensions/date_time.dart';
 import 'package:danawallet/extensions/network.dart';
+import 'package:danawallet/extensions/outpoint.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 import 'package:danawallet/generated/rust/api/structs/outpoint.dart';
 import 'package:danawallet/generated/rust/api/structs/owned_output.dart';
 import 'package:danawallet/generated/rust/api/structs/recipient.dart';
+import 'package:danawallet/generated/rust/api/structs/state_update.dart';
 import 'package:danawallet/generated/rust/api/structs/unsigned_transaction.dart';
 import 'package:danawallet/data/models/recorded_transaction.dart';
 import 'package:danawallet/generated/rust/api/structs/network.dart';
@@ -84,8 +86,58 @@ class WalletState extends ChangeNotifier {
     return true;
   }
 
-  Future<void> refreshAfterSync({bool lastSyncOnly = false}) async {
+  Future<void> processUpdate(StateUpdate update) async {
     if (!_initialized) return;
+    // Process found outputs (new UTXOs we own)
+    for (final found in update.foundOutputs) {
+      // first, insert the transaction data in the known transactions table
+      await transactionsRepository.addIncomingTransaction(
+        txid: found.outpoint.txid,
+        confirmationHeight: update.blkheight,
+        confirmationBlockhash: update.blkhash,
+      );
+
+      // Insert output into database
+      await ownedOutputsRepository.insertOutput(output: found);
+    }
+
+    List<OutPoint> unknownSpends = [];
+
+    // Process found inputs (our UTXOs being spent)
+    for (final outpoint in update.foundInputs) {
+      // Try to confirm an outgoing transaction
+      final confirmed = await transactionsRepository.confirmOutgoingTransaction(
+        confirmedOutpointTxid: outpoint.txid,
+        confirmedOutpointVout: outpoint.vout,
+        confirmationHeight: update.blkheight,
+        confirmationBlockhash: update.blkhash,
+      );
+
+      // this output does not have an associated transaction
+      // this can occur if a user imported their seed phrase in multiple wallets
+      // generally we should discourage this, but it's inevitable that it will happen
+      if (!confirmed) {
+        unknownSpends.add(outpoint);
+      }
+    }
+
+    if (unknownSpends.isNotEmpty) {
+      Logger().w(
+          "Unknown spends detected, marking the following outpoints as spent: ${unknownSpends.toDisplayString()}");
+      await transactionsRepository.addOutgoingTransaction(
+        spentOutpoints: unknownSpends,
+        recipients: [],
+        txid: null,
+        confirmationHeight: update.blkheight,
+        confirmationBlockhash: update.blkhash,
+      );
+    }
+
+    await walletRepository.saveLastSync(update.blkheight);
+
+    // update UI
+    final lastSyncOnly =
+        update.foundOutputs.isEmpty && update.foundInputs.isEmpty;
     await _updateWalletState(lastSyncOnly: lastSyncOnly);
     notifyListeners();
   }

--- a/rust/src/api/structs/owned_output.rs
+++ b/rust/src/api/structs/owned_output.rs
@@ -1,9 +1,10 @@
 use flutter_rust_bridge::frb;
+use serde::{Deserialize, Serialize};
 
 use crate::api::structs::amount::Amount;
 use crate::api::structs::outpoint::OutPoint;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[frb]
 pub struct OwnedOutput {
     pub outpoint: OutPoint,

--- a/rust/src/api/structs/state_update.rs
+++ b/rust/src/api/structs/state_update.rs
@@ -1,15 +1,30 @@
 use std::collections::HashSet;
 
 use flutter_rust_bridge::frb;
+use serde::{Deserialize, Serialize};
 
 use crate::api::structs::outpoint::OutPoint;
 use crate::api::structs::owned_output::OwnedOutput;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 #[frb]
 pub struct StateUpdate {
     pub blkheight: u32,
     pub blkhash: String,
     pub found_outputs: Vec<OwnedOutput>,
     pub found_inputs: HashSet<OutPoint>,
+}
+
+impl StateUpdate {
+    // these encode and decode functions are used to send the state update betweeen the flutter
+    // foreground thread and the main isolate, since only primitive types are allowed
+    #[frb(sync)]
+    pub fn decode(encoded: String) -> Self {
+        serde_json::from_str(&encoded).unwrap()
+    }
+
+    #[frb(sync)]
+    pub fn encode(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
 }


### PR DESCRIPTION
Instead of processing state updates in the sync engine and sending an
update flag to the main isolate, we send the entire update to the main
isolate. This restores the responsibility of processing state updates
back to the WalletState, as it used to be before https://github.com/cygnet3/dana/pull/338.