### PR TITLE
Feat/parse btc amt

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -62,3 +62,7 @@ const String bgKeyFatalError = 'fatalError';
 
 // Message keys sent to the background sync service from the main isolate.
 const String bgKeySync = 'sync';
+
+// Enforce english convention for amounts inputs
+const String decimalSeparator = '.';
+const String groupSeparator = ',';

--- a/lib/extensions/api_amount.dart
+++ b/lib/extensions/api_amount.dart
@@ -1,6 +1,73 @@
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 
+BigInt _btcStringToSats(String wholePart, String fractionPart) {
+  if (fractionPart.length > 8) {
+    throw const FormatException('BTC amount has too many decimal places');
+  }
+
+  final whole = BigInt.parse(wholePart);
+  final fractionSats = BigInt.parse(fractionPart.padRight(8, '0'));
+
+  final sats = whole * BigInt.from(bitcoinUnits) + fractionSats;
+  if (sats <= BigInt.zero) {
+    throw const FormatException('Amount must be positive');
+  }
+  return sats;
+}
+
+(String, String) _parseDecimal(String input) {
+  final parts = input.split(decimalSeparator);
+  if (parts.length == 1) {
+    return (input, ''); // We return only the whole part
+  }
+  if (parts.length != 2) {
+    // Having more than one decimal separator is invalid input
+    throw FormatException('Invalid BTC amount: $input');
+  }
+
+  final wholePart = parts[0];
+  if (wholePart.isEmpty) {
+    throw const FormatException('BTC amount has an empty whole part');
+  } else if (wholePart.contains(RegExp(r'\D'))) {
+    throw FormatException(
+        'BTC amount has an invalid whole part \'$wholePart\'');
+  }
+  final fractionPart = parts[1];
+  if (fractionPart.length > 8) {
+    throw const FormatException('BTC amount has too many decimal places');
+  } else if (fractionPart.isEmpty) {
+    throw const FormatException('BTC amount with empty fraction part');
+  }
+  return (wholePart, fractionPart);
+}
+
+String _validateGroupsDigits(String wholePart) {
+  final parts = wholePart.split(groupSeparator);
+  if (parts.length > 1) {
+    // We protect against trailing comma at the beginning
+    if (parts[0].isEmpty) {
+      throw const FormatException(
+          'Incorrectly formatted number: starting with a \'$groupSeparator\'');
+    }
+    // Other than the first part, each part must be 3 digits
+    for (var i = 1; i < parts.length; i++) {
+      final part = parts[i];
+      if (part.length != 3) {
+        throw const FormatException(
+            'Group separator must be followed by exactly 3 digits');
+      } else if (part.contains(RegExp(r'\D'))) {
+        throw FormatException('Invalid character in grouped number $part');
+      }
+    }
+
+    return parts.join();
+  } else {
+    // There's no separator, just return the input as is
+    return wholePart;
+  }
+}
+
 extension AmountExtension on Amount {
   Amount operator +(Amount other) {
     return Amount(field0: field0 + other.field0);
@@ -12,6 +79,34 @@ extension AmountExtension on Amount {
 
   bool operator >(Amount other) {
     return field0 > other.field0;
+  }
+
+  bool operator <(Amount other) {
+    return field0 < other.field0;
+  }
+
+  /// Parses user-entered spend amounts. Integer strings are interpreted as
+  /// satoshis; non-integer strings are parsed as BTC.
+  static Amount parseUserInput(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) {
+      throw const FormatException('Amount is empty');
+    }
+
+    final (wholePart, fractionPart) = _parseDecimal(trimmed);
+    final sanitizedWholePart = _validateGroupsDigits(wholePart);
+
+    final hasDecimal = fractionPart.isNotEmpty;
+
+    if (!hasDecimal) {
+      final satsAmount = BigInt.parse(sanitizedWholePart);
+      if (satsAmount <= BigInt.zero) {
+        throw const FormatException('Amount must be positive');
+      }
+      return Amount(field0: satsAmount);
+    } else {
+      return Amount(field0: _btcStringToSats(sanitizedWholePart, fractionPart));
+    }
   }
 
   String displayBtc() {

--- a/lib/screens/spend/amount_selection.dart
+++ b/lib/screens/spend/amount_selection.dart
@@ -34,12 +34,9 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
       _amountErrorText = null;
     });
 
-    final BigInt amount;
+    final Amount amount;
     try {
-      amount = BigInt.from(int.parse(amountController.text));
-      if (amount <= BigInt.from(0)) {
-        throw const FormatException('Amount must be positive');
-      }
+      amount = AmountExtension.parseUserInput(amountController.text);
     } on FormatException catch (e) {
       setState(() {
         _amountErrorText = 'Invalid amount: $e';
@@ -52,14 +49,14 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
       return;
     }
 
-    if (amount > availableBalance.field0) {
+    if (amount > availableBalance) {
       setState(() {
         _amountErrorText = 'Not enough available funds';
       });
       return;
     }
 
-    if (amount < BigInt.from(defaultDustLimit)) {
+    if (amount < Amount(field0: BigInt.from(defaultDustLimit))) {
       setState(() {
         _amountErrorText = 'Please send at least $defaultDustLimit sats';
       });
@@ -68,7 +65,7 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
 
     final recipient = Recipient(
       paymentCode: widget.paymentCode,
-      amount: Amount(field0: amount),
+      amount: amount,
     );
 
     goToScreen(
@@ -145,8 +142,9 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
                   decoration: InputDecoration(
                     border: const OutlineInputBorder(),
                     labelText: 'Enter an amount',
+                    helperText:
+                        'Integer for sats, decimal (dot \'.\' separated) for BTC',
                     errorText: _amountErrorText,
-                    suffixText: 'sats',
                   ),
                   keyboardType: TextInputType.number,
                 ),

--- a/test/extensions/api_amount_test.dart
+++ b/test/extensions/api_amount_test.dart
@@ -1,0 +1,147 @@
+import 'package:danawallet/constants.dart';
+import 'package:danawallet/extensions/api_amount.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AmountExtension.parseUserInput', () {
+    test('parses integer strings as satoshis', () {
+      final amount = AmountExtension.parseUserInput('1000');
+
+      expect(amount.field0, BigInt.from(1000));
+    });
+
+    test('trims whitespace before parsing', () {
+      final amount = AmountExtension.parseUserInput('  546  ');
+
+      expect(amount.field0, BigInt.from(546));
+    });
+
+    test('parses large integer strings as satoshis', () {
+      final amount = AmountExtension.parseUserInput('9223372036854775808');
+
+      expect(amount.field0, BigInt.parse('9223372036854775808'));
+    });
+
+    test('parses decimal strings as BTC', () {
+      final amount = AmountExtension.parseUserInput('1.5');
+
+      expect(amount.field0, BigInt.from(150000000));
+    });
+
+    test('parses BTC strings with trailing fractional zeros', () {
+      final amount = AmountExtension.parseUserInput('1.0');
+
+      expect(amount.field0, BigInt.from(bitcoinUnits));
+    });
+
+    test('parses the smallest BTC unit as one satoshi', () {
+      final amount = AmountExtension.parseUserInput('0.00000001');
+
+      expect(amount.field0, BigInt.one);
+    });
+
+    test('throws when input is empty', () {
+      expect(
+        () => AmountExtension.parseUserInput(''),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws when integer amount is zero', () {
+      expect(
+        () => AmountExtension.parseUserInput('0'),
+        throwsA(
+          predicate<FormatException>(
+            (e) => e.message == 'Amount must be positive',
+          ),
+        ),
+      );
+    });
+
+    test('throws when BTC amount is zero', () {
+      expect(
+        () => AmountExtension.parseUserInput('0.0'),
+        throwsA(
+          predicate<FormatException>(
+            (e) => e.message == 'Amount must be positive',
+          ),
+        ),
+      );
+    });
+
+    test('throws when sats amount is negative', () {
+      expect(
+        () => AmountExtension.parseUserInput('-1000'),
+        throwsA(
+          predicate<FormatException>(
+            (e) => e.message == 'Amount must be positive',
+          ),
+        ),
+      );
+    });
+
+    test('throws when BTC amount is negative', () {
+      expect(
+        () => AmountExtension.parseUserInput('-1.1234'),
+        throwsA(
+          predicate<FormatException>(
+            (e) => e.message == 'Amount must be positive',
+          ),
+        ),
+      );
+    });
+    test('throws when BTC has too many decimal places', () {
+      expect(
+        () => AmountExtension.parseUserInput('1.123456789'),
+        throwsA(
+          predicate<FormatException>(
+            (e) => e.message == 'BTC amount has too many decimal places',
+          ),
+        ),
+      );
+    });
+
+    test('throws when input is not a valid amount', () {
+      expect(
+        () => AmountExtension.parseUserInput('not-an-amount'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    group('en_US locale formatting', () {
+      test('parses grouped integer strings as satoshis', () {
+        final amount = AmountExtension.parseUserInput('1,000');
+
+        expect(amount.field0, BigInt.from(1000));
+      });
+
+      test('parses large grouped integer strings as satoshis', () {
+        final amount = AmountExtension.parseUserInput('21,000,000');
+
+        expect(amount.field0, BigInt.from(21000000));
+      });
+
+      test('parses grouped decimal strings as BTC', () {
+        final amount = AmountExtension.parseUserInput('1,234.5');
+
+        expect(amount.field0, BigInt.from(1234.5 * bitcoinUnits));
+      });
+    });
+
+    group('non-en_US formatting', () {
+      test('rejects French-style comma decimals by default', () {
+        expect(
+          () => AmountExtension.parseUserInput('1,5'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('rejects French-style spaced thousands by default', () {
+        expect(
+          () => AmountExtension.parseUserInput('1 000'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Allow user to input either a float (BTC amount) or int (sats) in the amount field of the send screen.

Only the english locale is accepted for now.