### PR TITLE
fix: Check for chainState.available before calculating blocksToScan

### DIFF
--- a/lib/screens/spend/amount_selection.dart
+++ b/lib/screens/spend/amount_selection.dart
@@ -87,7 +87,7 @@ class AmountSelectionScreenState extends State<AmountSelectionScreen> {
 
     final availableBalance = walletState.amount;
     int blocksToScan = 0;
-    if (walletState.lastSync != null) {
+    if (walletState.lastSync != null && chainState.available) {
       blocksToScan = chainState.tip - walletState.lastSync!;
     }
 


### PR DESCRIPTION
If we start the wallet offline and try to open the send screen, this crashes because chainState.tip is null. The fix is simply to check for chainState.available first.