### PR TITLE
feat: refresh exchange rates

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,7 +71,7 @@ void main() async {
   final chainState = ChainState();
   final contactsState = ContactsState();
   final displayPreferencesState = await DisplayPreferencesState.create();
-  final fiatExchangeRate = await FiatExchangeRateState.create();
+  final fiatExchangeRate = FiatExchangeRateState();
 
   final syncOrchestrator = SyncOrchestrator(
     chainState: chainState,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,7 +81,7 @@ void main() async {
   );
 
   // fetch the exchange rate, but don't await the response
-  fiatExchangeRate.updateExchangeRate();
+  fiatExchangeRate.updateExchangeRates();
 
   await precacheImages();
 

--- a/lib/screens/contacts/contact_details.dart
+++ b/lib/screens/contacts/contact_details.dart
@@ -298,7 +298,7 @@ class ContactDetailsScreen extends StatelessWidget {
   ListTile _buildTransactionTile(
       RecordedTransaction tx,
       FiatExchangeRateState exchangeRate,
-      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference,
       Contact contact) {
     if (tx is! RecordedTransactionOutgoing) {
       throw Exception('Expected outgoing transaction');
@@ -310,7 +310,8 @@ class ContactDetailsScreen extends StatelessWidget {
         tx.confirmationHeight == null ? Bitcoin.neutral4 : Bitcoin.red;
     final amount = tx.totalOutgoing();
     const amountprefix = '-';
-    final amountFiat = exchangeRate.displayFiat(amount);
+    final amountFiat =
+        exchangeRate.displayFiat(amount, displayPreference.fiatCurrency);
     const title = 'Outgoing transaction';
     final text = tx.toString();
     final image = Image(
@@ -327,7 +328,8 @@ class ContactDetailsScreen extends StatelessWidget {
             style: BitcoinTextStyle.body4(Bitcoin.black),
           ),
           const Spacer(),
-          Text('$amountprefix ${amount.display(bitcoinUnit)}',
+          Text(
+              '$amountprefix ${amount.display(displayPreference.amountDisplayUnit)}',
               style: BitcoinTextStyle.body4(color)),
         ],
       ),
@@ -353,7 +355,7 @@ class ContactDetailsScreen extends StatelessWidget {
   void _showSentTransactionsSheet(BuildContext context, Contact contact) {
     final exchangeRate =
         Provider.of<FiatExchangeRateState>(context, listen: false);
-    final displayPrefrence =
+    final displayPreference =
         Provider.of<DisplayPreferencesState>(context, listen: false);
     final sentTransactions = _getSentTransactions(context, contact);
 
@@ -378,7 +380,7 @@ class ContactDetailsScreen extends StatelessWidget {
                     return _buildTransactionTile(
                       sentTransactions[sentTransactions.length - 1 - index],
                       exchangeRate,
-                      displayPrefrence.amountDisplayUnit,
+                      displayPreference,
                       contact,
                     );
                   },

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
+import 'package:danawallet/states/fiat_exchange_rate_state.dart';
 import 'package:danawallet/states/home_state.dart';
 import 'package:danawallet/screens/contacts/contacts.dart';
 import 'package:danawallet/screens/wallet/wallet.dart';
@@ -92,7 +93,15 @@ class HomeScreen extends StatelessWidget {
             ],
             currentIndex: homeState.selectedIndex,
             selectedItemColor: Bitcoin.blue,
-            onTap: homeState.setIndex,
+            onTap: (index) {
+              if (index == 0) {
+                unawaited(context
+                    .read<FiatExchangeRateState>()
+                    .updateExchangeRates());
+              }
+
+              homeState.setIndex(index);
+            },
           ),
         ));
   }

--- a/lib/screens/settings/personalization/personalisation_settings_screen.dart
+++ b/lib/screens/settings/personalization/personalisation_settings_screen.dart
@@ -61,7 +61,7 @@ class PersonalisationSettingsScreen extends StatelessWidget {
               currentCurrency: displayPreferences.fiatCurrency,
               onConfirm: (chosen) async {
                 await displayPreferences.updateFiatCurrency(chosen);
-                unawaited(fiatExchangeRate.updateExchangeRate());
+                unawaited(fiatExchangeRate.updateExchangeRates());
 
                 if (context.mounted) {
                   goToHomeScreen(context);

--- a/lib/screens/settings/personalization/personalisation_settings_screen.dart
+++ b/lib/screens/settings/personalization/personalisation_settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bitcoin_ui/bitcoin_ui.dart';
 import 'package:danawallet/global_functions.dart';
 import 'package:danawallet/screens/settings/personalization/change_amount_display_screen.dart';
@@ -59,7 +61,7 @@ class PersonalisationSettingsScreen extends StatelessWidget {
               currentCurrency: displayPreferences.fiatCurrency,
               onConfirm: (chosen) async {
                 await displayPreferences.updateFiatCurrency(chosen);
-                await fiatExchangeRate.updateCurrency(chosen);
+                unawaited(fiatExchangeRate.updateExchangeRate());
 
                 if (context.mounted) {
                   goToHomeScreen(context);

--- a/lib/screens/spend/custom_fee_screen.dart
+++ b/lib/screens/spend/custom_fee_screen.dart
@@ -260,7 +260,8 @@ class _CustomFeeScreenState extends State<CustomFeeScreen> {
                             _isLoadingFees
                                 ? 'Loading...'
                                 : exchangeRate.displayFiat(
-                                    _feeAmounts[_selectedFeeRate]!),
+                                    _feeAmounts[_selectedFeeRate]!,
+                                    displayPreference.fiatCurrency),
                             style: BitcoinTextStyle.body5(Bitcoin.neutral7),
                           ),
                         ],

--- a/lib/screens/spend/fee_selection.dart
+++ b/lib/screens/spend/fee_selection.dart
@@ -100,8 +100,11 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
     }
   }
 
-  ListTile toListTile(SelectedFee fee, FiatExchangeRateState exchangeRate,
-      AmountDisplayUnit bitcoinUnit) {
+  ListTile toListTile(
+      SelectedFee fee,
+      FiatExchangeRateState exchangeRate,
+      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference) {
     switch (fee) {
       case SelectedFee.fast:
       case SelectedFee.normal:
@@ -117,7 +120,8 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
             throw Exception('Fee amount not computed for $fee');
           }
           subtitleBtc = estimatedFee.display(bitcoinUnit);
-          subtitleFiat = exchangeRate.displayFiat(estimatedFee);
+          subtitleFiat = exchangeRate.displayFiat(
+              estimatedFee, displayPreference.fiatCurrency);
         }
 
         return ListTile(
@@ -194,14 +198,18 @@ class FeeSelectionScreenState extends State<FeeSelectionScreen> {
           },
           child: Column(children: [
             const Divider(),
-            toListTile(SelectedFee.fast, exchangeRate, bitcoinUnit),
+            toListTile(
+                SelectedFee.fast, exchangeRate, bitcoinUnit, displayPreference),
             const Divider(),
-            toListTile(SelectedFee.normal, exchangeRate, bitcoinUnit),
+            toListTile(SelectedFee.normal, exchangeRate, bitcoinUnit,
+                displayPreference),
             const Divider(),
-            toListTile(SelectedFee.slow, exchangeRate, bitcoinUnit),
+            toListTile(
+                SelectedFee.slow, exchangeRate, bitcoinUnit, displayPreference),
             const Divider(),
             if (isDevEnv)
-              toListTile(SelectedFee.custom, exchangeRate, bitcoinUnit),
+              toListTile(SelectedFee.custom, exchangeRate, bitcoinUnit,
+                  displayPreference),
             if (isDevEnv) const Divider(),
           ])),
       footer: Column(

--- a/lib/screens/wallet/wallet.dart
+++ b/lib/screens/wallet/wallet.dart
@@ -187,13 +187,17 @@ class WalletScreenState extends State<WalletScreen> {
     }
   }
 
-  Widget buildAmountDisplay(Amount amount, FiatExchangeRateState exchangeRate,
-      AmountDisplayUnit bitcoinUnit) {
+  Widget buildAmountDisplay(
+      Amount amount,
+      FiatExchangeRateState exchangeRate,
+      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference) {
     String btcAmount =
         hideAmount ? hideAmountFormat : amount.display(bitcoinUnit);
 
-    String fiatAmount =
-        hideAmount ? hideAmountFormat : exchangeRate.displayFiat(amount);
+    String fiatAmount = hideAmount
+        ? hideAmountFormat
+        : exchangeRate.displayFiat(amount, displayPreference.fiatCurrency);
 
     return GestureDetector(
       onTap: () => setState(() {
@@ -217,8 +221,11 @@ class WalletScreenState extends State<WalletScreen> {
     );
   }
 
-  ListTile toListTile(RecordedTransaction tx,
-      FiatExchangeRateState exchangeRate, AmountDisplayUnit bitcoinUnit) {
+  ListTile toListTile(
+      RecordedTransaction tx,
+      FiatExchangeRateState exchangeRate,
+      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference) {
     Color? color;
     String amount;
     String amountprefix;
@@ -243,7 +250,8 @@ class WalletScreenState extends State<WalletScreen> {
         amountprefix = '+';
         amountFiat = hideAmount
             ? hideAmountFormat
-            : exchangeRate.displayFiat(incoming.amount);
+            : exchangeRate.displayFiat(
+                incoming.amount, displayPreference.fiatCurrency);
         leadingWidget = Image(
             image: const AssetImage("icons/receive.png", package: "bitcoin_ui"),
             color: Bitcoin.neutral3Dark);
@@ -268,7 +276,8 @@ class WalletScreenState extends State<WalletScreen> {
         amountprefix = '-';
         amountFiat = hideAmount
             ? hideAmountFormat
-            : exchangeRate.displayFiat(outgoing.totalOutgoing());
+            : exchangeRate.displayFiat(
+                outgoing.totalOutgoing(), displayPreference.fiatCurrency);
         // Show contact avatar if contact is known, otherwise show send icon
         final contact = paymentCode != null
             ? contactsState.getContactByPaymentCode(paymentCode)
@@ -301,7 +310,8 @@ class WalletScreenState extends State<WalletScreen> {
         amountprefix = '-';
         amountFiat = hideAmount
             ? hideAmountFormat
-            : exchangeRate.displayFiat(unknown.amount);
+            : exchangeRate.displayFiat(
+                unknown.amount, displayPreference.fiatCurrency);
         leadingWidget = Image(
             image: const AssetImage("icons/send.png", package: "bitcoin_ui"),
             color: Bitcoin.neutral3Dark);
@@ -328,8 +338,11 @@ class WalletScreenState extends State<WalletScreen> {
     );
   }
 
-  void _showFullTransactionHistory(List<RecordedTransaction> transactions,
-      FiatExchangeRateState exchangeRate, AmountDisplayUnit bitcoinUnit) {
+  void _showFullTransactionHistory(
+      List<RecordedTransaction> transactions,
+      FiatExchangeRateState exchangeRate,
+      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference) {
     showAppBottomSheet(
       context: context,
       builder: (context) => DraggableScrollableSheet(
@@ -375,8 +388,8 @@ class WalletScreenState extends State<WalletScreen> {
                             const Divider(),
                         itemCount: transactions.length,
                         itemBuilder: (context, index) {
-                          return toListTile(
-                              transactions[index], exchangeRate, bitcoinUnit);
+                          return toListTile(transactions[index], exchangeRate,
+                              bitcoinUnit, displayPreference);
                         },
                       ),
               ),
@@ -387,8 +400,11 @@ class WalletScreenState extends State<WalletScreen> {
     );
   }
 
-  Widget buildTransactionHistory(List<RecordedTransaction> transactions,
-      FiatExchangeRateState exchangeRate, AmountDisplayUnit bitcoinUnit) {
+  Widget buildTransactionHistory(
+      List<RecordedTransaction> transactions,
+      FiatExchangeRateState exchangeRate,
+      AmountDisplayUnit bitcoinUnit,
+      DisplayPreferencesState displayPreference) {
     if (transactions.isEmpty) {
       return Center(
           child: Text('No transactions yet.',
@@ -410,7 +426,8 @@ class WalletScreenState extends State<WalletScreen> {
           return Column(
             children: [
               if (index > 0) const Divider(height: 1),
-              toListTile(preview[index], exchangeRate, bitcoinUnit),
+              toListTile(
+                  preview[index], exchangeRate, bitcoinUnit, displayPreference),
             ],
           );
         }),
@@ -418,7 +435,7 @@ class WalletScreenState extends State<WalletScreen> {
           const Divider(height: 1),
           GestureDetector(
             onTap: () => _showFullTransactionHistory(
-                transactions, exchangeRate, bitcoinUnit),
+                transactions, exchangeRate, bitcoinUnit, displayPreference),
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 12),
               child: Text(
@@ -650,14 +667,14 @@ class WalletScreenState extends State<WalletScreen> {
                     maintainState: true,
                     child: buildOfflineStatus(chainState)),
                 const SizedBox(height: 20.0),
-                buildAmountDisplay(
-                    amount, exchangeRate, displayPreference.amountDisplayUnit),
+                buildAmountDisplay(amount, exchangeRate,
+                    displayPreference.amountDisplayUnit, displayPreference),
                 const SizedBox(height: 20.0),
                 // Show Dana address banner if available
                 if (danaAddress != null) buildDanaAddressBanner(danaAddress),
                 const Spacer(),
                 buildTransactionHistory(walletState.transactions, exchangeRate,
-                    displayPreference.amountDisplayUnit),
+                    displayPreference.amountDisplayUnit, displayPreference),
                 buildBottomButtons(walletState.receivePaymentCode),
                 const SizedBox(
                   height: 20.0,

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -42,6 +42,14 @@ class FiatExchangeRateState extends ChangeNotifier {
   Map<FiatCurrency, int> get exchangeRates => Map.unmodifiable(_cachedRates);
   int? exchangeRateFor(FiatCurrency currency) => _cachedRates[currency];
   DateTime? get lastExchangeRateUpdateAt => _lastExchangeRateUpdateAt;
+
+  /// Elapsed time since the last successful rate update, or `null` if never updated.
+  Duration? get timeSinceLastExchangeRateUpdate {
+    final lastUpdate = _lastExchangeRateUpdateAt;
+    if (lastUpdate == null) return null;
+    return DateTime.now().toUtc().difference(lastUpdate);
+  }
+
   bool get isUpdating => _isUpdating;
 
   Future<void> updateExchangeRates() async {

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:danawallet/constants.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 import 'package:danawallet/data/enums/fiat_currency.dart';
@@ -10,7 +12,7 @@ class FiatExchangeRateState extends ChangeNotifier {
   MempoolApiRepository repository = MempoolApiRepository();
 
   late FiatCurrency currency;
-  double? _cachedRate; // Make nullable to represent "no data available"
+  int? _cachedRate;
 
   // private constructor, create class using static async 'create' instead
   FiatExchangeRateState._();
@@ -24,9 +26,7 @@ class FiatExchangeRateState extends ChangeNotifier {
     return instance;
   }
 
-  double? get exchangeRate {
-    return _cachedRate; // Can be null if no data available
-  }
+  int? get exchangeRate => _cachedRate;
 
   Future<void> updateCurrency(FiatCurrency currency) async {
     await SettingsRepository.instance.setFiatCurrency(currency);
@@ -52,36 +52,50 @@ class FiatExchangeRateState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<double> _fetchExchangeRate(FiatCurrency currency) async {
+  Future<int> _fetchExchangeRate(FiatCurrency currency) async {
     final rates = await repository.getExchangeRate();
 
     switch (currency) {
       case FiatCurrency.eur:
-        return rates.eur.toDouble();
+        return rates.eur;
       case FiatCurrency.usd:
-        return rates.usd.toDouble();
+        return rates.usd;
       case FiatCurrency.gbp:
-        return rates.gbp.toDouble();
+        return rates.gbp;
       case FiatCurrency.cad:
-        return rates.cad.toDouble();
+        return rates.cad;
       case FiatCurrency.chf:
-        return rates.chf.toDouble();
+        return rates.chf;
       case FiatCurrency.aud:
-        return rates.aud.toDouble();
+        return rates.aud;
       case FiatCurrency.jpy:
-        return rates.jpy.toDouble();
+        return rates.jpy;
     }
+  }
+
+  BigInt _satsToFiatMinor(Amount amount, int rate) {
+    final scale = pow(10, currency.minorUnits()).toInt();
+    return amount.field0 *
+        BigInt.from(rate) *
+        BigInt.from(scale) ~/
+        BigInt.from(bitcoinUnits);
   }
 
   String displayFiat(Amount amount) {
     final symbol = currency.symbol();
     final minorUnits = currency.minorUnits();
-    if (_cachedRate != null) {
-      final btcAmount = amount.field0.toDouble() / bitcoinUnits.toDouble();
-      final fiatAmount = btcAmount * _cachedRate!;
-      return "$symbol ${fiatAmount.toStringAsFixed(minorUnits)}";
-    } else {
-      return "$symbol ---";
+    final rate = _cachedRate;
+    if (rate == null) {
+      return '$symbol ---';
     }
+
+    final minor = _satsToFiatMinor(amount, rate);
+    if (minorUnits == 0) {
+      return '$symbol $minor';
+    }
+    final scale = BigInt.from(pow(10, minorUnits));
+    final whole = minor ~/ scale;
+    final fraction = (minor % scale).toString().padLeft(minorUnits, '0');
+    return '$symbol $whole.$fraction';
   }
 }

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -13,11 +13,7 @@ class FiatExchangeRateState extends ChangeNotifier {
 
   Map<FiatCurrency, int> _cachedRates = const {};
 
-  FiatExchangeRateState._();
-
-  static Future<FiatExchangeRateState> create() async {
-    return FiatExchangeRateState._();
-  }
+  FiatExchangeRateState();
 
   Map<FiatCurrency, int> get exchangeRates => Map.unmodifiable(_cachedRates);
   int? exchangeRateFor(FiatCurrency currency) => _cachedRates[currency];

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -5,37 +5,22 @@ import 'package:danawallet/data/models/mempool_prices_response.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 import 'package:danawallet/data/enums/fiat_currency.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
-import 'package:danawallet/repositories/settings_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 
 class FiatExchangeRateState extends ChangeNotifier {
   MempoolApiRepository repository = MempoolApiRepository();
 
-  late FiatCurrency currency;
   Map<FiatCurrency, int> _cachedRates = const {};
 
-  // private constructor, create class using static async 'create' instead
   FiatExchangeRateState._();
 
   static Future<FiatExchangeRateState> create() async {
-    final instance = FiatExchangeRateState._();
-    final currency =
-        await SettingsRepository.instance.getFiatCurrency() ?? defaultCurrency;
-    instance.currency = currency;
-
-    return instance;
+    return FiatExchangeRateState._();
   }
 
   Map<FiatCurrency, int> get exchangeRates => Map.unmodifiable(_cachedRates);
   int? exchangeRateFor(FiatCurrency currency) => _cachedRates[currency];
-  int? get exchangeRate => exchangeRateFor(currency);
-
-  Future<void> updateCurrency(FiatCurrency currency) async {
-    await SettingsRepository.instance.setFiatCurrency(currency);
-    this.currency = currency;
-    notifyListeners();
-  }
 
   Future<void> updateExchangeRate() async {
     try {
@@ -70,7 +55,7 @@ class FiatExchangeRateState extends ChangeNotifier {
     };
   }
 
-  BigInt _satsToFiatMinor(Amount amount, int rate) {
+  BigInt _satsToFiatMinor(Amount amount, int rate, FiatCurrency currency) {
     final scale = pow(10, currency.minorUnits()).toInt();
     return amount.field0 *
         BigInt.from(rate) *
@@ -78,21 +63,18 @@ class FiatExchangeRateState extends ChangeNotifier {
         BigInt.from(bitcoinUnits);
   }
 
-  String displayFiat(Amount amount) {
-    final symbol = currency.symbol();
-    final minorUnits = currency.minorUnits();
-    final rate = exchangeRate;
-    if (rate == null) {
-      return '$symbol ---';
-    }
+  String displayFiat(Amount amount, FiatCurrency currency) {
+    final rate = exchangeRateFor(currency);
+    if (rate == null) return '${currency.symbol()} ---';
 
-    final minor = _satsToFiatMinor(amount, rate);
+    final minor = _satsToFiatMinor(amount, rate, currency);
+    final minorUnits = currency.minorUnits();
     if (minorUnits == 0) {
-      return '$symbol $minor';
+      return '${currency.symbol()} $minor';
     }
     final scale = BigInt.from(pow(10, minorUnits));
     final whole = minor ~/ scale;
     final fraction = (minor % scale).toString().padLeft(minorUnits, '0');
-    return '$symbol $whole.$fraction';
+    return '${currency.symbol()} $whole.$fraction';
   }
 }

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:danawallet/constants.dart';
+import 'package:danawallet/data/models/mempool_prices_response.dart';
 import 'package:danawallet/generated/rust/api/structs/amount.dart';
 import 'package:danawallet/data/enums/fiat_currency.dart';
 import 'package:danawallet/repositories/mempool_api_repository.dart';
@@ -12,7 +13,7 @@ class FiatExchangeRateState extends ChangeNotifier {
   MempoolApiRepository repository = MempoolApiRepository();
 
   late FiatCurrency currency;
-  int? _cachedRate;
+  Map<FiatCurrency, int> _cachedRates = const {};
 
   // private constructor, create class using static async 'create' instead
   FiatExchangeRateState._();
@@ -26,51 +27,47 @@ class FiatExchangeRateState extends ChangeNotifier {
     return instance;
   }
 
-  int? get exchangeRate => _cachedRate;
+  Map<FiatCurrency, int> get exchangeRates => Map.unmodifiable(_cachedRates);
+  int? exchangeRateFor(FiatCurrency currency) => _cachedRates[currency];
+  int? get exchangeRate => exchangeRateFor(currency);
 
   Future<void> updateCurrency(FiatCurrency currency) async {
     await SettingsRepository.instance.setFiatCurrency(currency);
     this.currency = currency;
-
-    // Reset exchange rate when currency changes
-    _cachedRate = null;
     notifyListeners();
-
-    // Try to fetch fresh data for new currency
-    return await updateExchangeRate();
   }
 
   Future<void> updateExchangeRate() async {
     try {
-      Logger().i("Updating exchange rate: ${currency.displayName()}");
-      final rate = await _fetchExchangeRate(currency);
-      _cachedRate = rate;
+      Logger().i('Updating exchange rates for all currencies');
+      _cachedRates = await _fetchExchangeRates();
     } catch (e) {
       Logger().w('Failed to update exchange rate: $e');
-      _cachedRate = null;
     }
     notifyListeners();
   }
 
-  Future<int> _fetchExchangeRate(FiatCurrency currency) async {
+  Future<Map<FiatCurrency, int>> _fetchExchangeRates() async {
     final rates = await repository.getExchangeRate();
-
-    switch (currency) {
-      case FiatCurrency.eur:
-        return rates.eur;
-      case FiatCurrency.usd:
-        return rates.usd;
-      case FiatCurrency.gbp:
-        return rates.gbp;
-      case FiatCurrency.cad:
-        return rates.cad;
-      case FiatCurrency.chf:
-        return rates.chf;
-      case FiatCurrency.aud:
-        return rates.aud;
-      case FiatCurrency.jpy:
-        return rates.jpy;
+    final mappedRates = _mapRatesByCurrency(rates);
+    for (final entry in mappedRates.entries) {
+      if (entry.value <= 0) {
+        throw Exception('invalid rate for ${entry.key.name}: ${entry.value}');
+      }
     }
+    return mappedRates;
+  }
+
+  Map<FiatCurrency, int> _mapRatesByCurrency(MempoolPricesResponse rates) {
+    return {
+      FiatCurrency.usd: rates.usd,
+      FiatCurrency.eur: rates.eur,
+      FiatCurrency.gbp: rates.gbp,
+      FiatCurrency.cad: rates.cad,
+      FiatCurrency.chf: rates.chf,
+      FiatCurrency.aud: rates.aud,
+      FiatCurrency.jpy: rates.jpy,
+    };
   }
 
   BigInt _satsToFiatMinor(Amount amount, int rate) {
@@ -84,7 +81,7 @@ class FiatExchangeRateState extends ChangeNotifier {
   String displayFiat(Amount amount) {
     final symbol = currency.symbol();
     final minorUnits = currency.minorUnits();
-    final rate = _cachedRate;
+    final rate = exchangeRate;
     if (rate == null) {
       return '$symbol ---';
     }

--- a/lib/states/fiat_exchange_rate_state.dart
+++ b/lib/states/fiat_exchange_rate_state.dart
@@ -9,23 +9,63 @@ import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 
 class FiatExchangeRateState extends ChangeNotifier {
+  static const _minRefreshInterval = Duration(minutes: 1);
+
   MempoolApiRepository repository = MempoolApiRepository();
 
   Map<FiatCurrency, int> _cachedRates = const {};
+  DateTime? _lastExchangeRateUpdateAt;
+  bool _isUpdating = false;
 
   FiatExchangeRateState();
 
+  /// Visible for tests only.
+  static FiatExchangeRateState withRateForTesting({
+    required Map<FiatCurrency, int> rates,
+    DateTime? lastExchangeRateUpdateAt,
+  }) {
+    for (final entry in rates.entries) {
+      if (entry.value <= 0) {
+        throw ArgumentError.value(
+          entry.value,
+          'rates[${entry.key.name}]',
+          'must be a positive number',
+        );
+      }
+    }
+    final instance = FiatExchangeRateState();
+    instance._cachedRates = Map<FiatCurrency, int>.from(rates);
+    instance._lastExchangeRateUpdateAt = lastExchangeRateUpdateAt;
+    return instance;
+  }
+
   Map<FiatCurrency, int> get exchangeRates => Map.unmodifiable(_cachedRates);
   int? exchangeRateFor(FiatCurrency currency) => _cachedRates[currency];
+  DateTime? get lastExchangeRateUpdateAt => _lastExchangeRateUpdateAt;
+  bool get isUpdating => _isUpdating;
 
-  Future<void> updateExchangeRate() async {
+  Future<void> updateExchangeRates() async {
+    if (_isUpdating) return;
+
+    final lastUpdate = _lastExchangeRateUpdateAt;
+    if (lastUpdate != null &&
+        DateTime.now().toUtc().difference(lastUpdate) < _minRefreshInterval) {
+      return;
+    }
+
+    _isUpdating = true;
+    notifyListeners();
+
     try {
       Logger().i('Updating exchange rates for all currencies');
       _cachedRates = await _fetchExchangeRates();
+      _lastExchangeRateUpdateAt = DateTime.now().toUtc();
     } catch (e) {
-      Logger().w('Failed to update exchange rate: $e');
+      Logger().e('Failed to update exchange rate: $e');
+    } finally {
+      _isUpdating = false;
+      notifyListeners();
     }
-    notifyListeners();
   }
 
   Future<Map<FiatCurrency, int>> _fetchExchangeRates() async {

--- a/test/states/fiat_exchange_rate_state_test.dart
+++ b/test/states/fiat_exchange_rate_state_test.dart
@@ -1,0 +1,76 @@
+import 'package:danawallet/data/enums/fiat_currency.dart';
+import 'package:danawallet/data/models/mempool_prices_response.dart';
+import 'package:danawallet/repositories/mempool_api_repository.dart';
+import 'package:danawallet/states/fiat_exchange_rate_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FiatExchangeRateState.withRateForTesting', () {
+    test('rejects zero rate', () {
+      expect(
+        () => FiatExchangeRateState.withRateForTesting(
+          rates: {FiatCurrency.usd: 0},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('FiatExchangeRateState.updateExchangeRates', () {
+    test('keeps last known-good cache on refresh failure', () async {
+      final lastUpdated = DateTime.utc(2026, 1, 1, 10, 0, 0);
+      final state = FiatExchangeRateState.withRateForTesting(
+        rates: {FiatCurrency.usd: 50000},
+        lastExchangeRateUpdateAt: lastUpdated,
+      );
+      state.repository = _ThrowingMempoolApiRepository();
+
+      await state.updateExchangeRates();
+
+      expect(state.exchangeRateFor(FiatCurrency.usd), 50000);
+      expect(state.lastExchangeRateUpdateAt, lastUpdated);
+    });
+
+    test('skips refresh when last update was less than a minute ago', () async {
+      final repository = _CountingMempoolApiRepository();
+      final state = FiatExchangeRateState.withRateForTesting(
+        rates: {FiatCurrency.usd: 50000},
+        lastExchangeRateUpdateAt:
+            DateTime.now().toUtc().subtract(const Duration(seconds: 30)),
+      );
+      state.repository = repository;
+
+      await state.updateExchangeRates();
+
+      expect(repository.callCount, 0);
+      expect(state.exchangeRateFor(FiatCurrency.usd), 50000);
+      expect(state.isUpdating, isFalse);
+    });
+  });
+}
+
+class _CountingMempoolApiRepository extends MempoolApiRepository {
+  int callCount = 0;
+
+  @override
+  Future<MempoolPricesResponse> getExchangeRate() async {
+    callCount++;
+    return const MempoolPricesResponse(
+      timestamp: 0,
+      usd: 50000,
+      eur: 45000,
+      gbp: 40000,
+      cad: 65000,
+      chf: 45000,
+      aud: 75000,
+      jpy: 7000000,
+    );
+  }
+}
+
+class _ThrowingMempoolApiRepository extends MempoolApiRepository {
+  @override
+  Future<MempoolPricesResponse> getExchangeRate() async {
+    throw Exception('network down');
+  }
+}

--- a/test/states/fiat_exchange_rate_state_test.dart
+++ b/test/states/fiat_exchange_rate_state_test.dart
@@ -16,6 +16,27 @@ void main() {
     });
   });
 
+  group('FiatExchangeRateState.timeSinceLastExchangeRateUpdate', () {
+    test('returns null when never updated', () {
+      final state = FiatExchangeRateState();
+      expect(state.timeSinceLastExchangeRateUpdate, isNull);
+    });
+
+    test('returns elapsed duration since last update', () {
+      final lastUpdated =
+          DateTime.now().toUtc().subtract(const Duration(minutes: 5));
+      final state = FiatExchangeRateState.withRateForTesting(
+        rates: {FiatCurrency.usd: 50000},
+        lastExchangeRateUpdateAt: lastUpdated,
+      );
+
+      final elapsed = state.timeSinceLastExchangeRateUpdate;
+      expect(elapsed, isNotNull);
+      expect(elapsed!, greaterThanOrEqualTo(const Duration(minutes: 5)));
+      expect(elapsed, lessThan(const Duration(minutes: 6)));
+    });
+  });
+
   group('FiatExchangeRateState.updateExchangeRates', () {
     test('keeps last known-good cache on refresh failure', () async {
       final lastUpdated = DateTime.utc(2026, 1, 1, 10, 0, 0);


### PR DESCRIPTION
Important refactoring of `FiatExchangeRateState` in preparation of #433 

* Integer rates, one fetch for all currencies — Replaces a single double rate tied to the selected currency with a Map<FiatCurrency, int> filled in one API call. Fiat display uses integer minor-unit math instead of floats.
* Currency lives in display preferences, not exchange state — Drops currency / updateCurrency from FiatExchangeRateState. displayFiat(amount, FiatCurrency) takes the currency explicitly; wallet, fees, and contacts pass it from DisplayPreferencesState.
* Simpler lifecycle — Sync constructor (no async create()), 
* Throttling to avoid too frequent updates, add a lastExchangeRateUpdateAt so callers can tell when rates were last fetched.
* Refresh rates hooks — Refreshes rates when returning to the wallet tab and when changing fiat in settings; adds timeSinceLastExchangeRateUpdate for stale-rate warnings later.