### PR TITLE
refactor: move 'enable foreign keys pragma' to onConfigure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,9 +51,6 @@ void main() async {
   // Initialize database
   await DatabaseHelper.instance.database;
 
-  // after database migration, enable foreign_keys pragma
-  DatabaseHelper.instance.enableForeignKeysPragma();
-
   final walletState = WalletState.create();
   final permissionState = await PermissionState.create();
   final syncProgress = SyncProgressState.create();

--- a/lib/repositories/database_helper.dart
+++ b/lib/repositories/database_helper.dart
@@ -44,6 +44,7 @@ class DatabaseHelper {
       version: version,
       onUpgrade: (db, oldVersion, newVersion) =>
           _performMigrations(db, oldVersion, migrations),
+      onConfigure: _onConfigure,
     );
   }
 
@@ -60,8 +61,7 @@ class DatabaseHelper {
     }
   }
 
-  Future<void> enableForeignKeysPragma() async {
-    final db = await database;
+  Future<void> _onConfigure(Database db) async {
     await db.execute("PRAGMA foreign_keys = ON");
   }
 


### PR DESCRIPTION
Moves the enabling of the foreign keys pragma to the openDatabase onConfigure callback function. We couldn't do this before since this would mess with legacy migration, but this has been dropped as of #448.