### PR TITLE
dependencies: remove termcolor feature from simplelog

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1980,7 +1980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
 dependencies = [
  "log",
- "termcolor",
  "time 0.3.37",
 ]
 
@@ -2103,15 +2102,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2515,15 +2505,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.18.0"
 bip39 = { version = "2.0.0", features = ["rand"] }
 serde_with = "3.6.0"
 log = "0.4.20"
-simplelog = "0.12.1"
+simplelog = { version = "0.12.1", default-features = false, features = ["local-offset"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 pushtx = { git = "https://github.com/cygnet3/pushtx", branch = "master" }
 futures = "0.3"


### PR DESCRIPTION
I noticed that we're pulling a few dependencies along `simplelog` due to the `termcolor` feature that we don't use anyway. I suggest that we turn that feature off to remove those dependencies until we actually have a use for them.